### PR TITLE
Improve `de::Error`

### DIFF
--- a/src/de/enum/mod.rs
+++ b/src/de/enum/mod.rs
@@ -31,7 +31,7 @@ impl<'a, 'b, 'de> EnumAccess<'de> for Access<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::parse::Values;
+    use crate::de::{parse::Values, Position};
     use claim::assert_ok;
     use serde::{
         de,
@@ -70,7 +70,7 @@ mod tests {
             }
         }
 
-        let mut values = Values::new(b"foo", 0, 0);
+        let mut values = Values::new(b"foo", Position::new(0, 0));
         let access = Access::new(&mut values);
 
         let (variant, _variant_access) = assert_ok!(access.variant::<Variant>());

--- a/src/de/enum/variant/access.rs
+++ b/src/de/enum/variant/access.rs
@@ -45,14 +45,14 @@ impl<'a, 'b, 'de> VariantAccess<'de> for Access<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::parse::Values;
+    use crate::de::{parse::Values, Position};
     use claim::{assert_ok, assert_ok_eq};
     use serde::de::{Error, SeqAccess, VariantAccess, Visitor};
     use std::fmt;
 
     #[test]
     fn unit_variant() {
-        let mut values = Values::new(b"", 0, 0);
+        let mut values = Values::new(b"", Position::new(0, 0));
         let access = Access::new(&mut values);
 
         assert_ok!(access.unit_variant());
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn newtype_variant() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let access = Access::new(&mut values);
 
         assert_ok_eq!(access.newtype_variant::<u64>(), 42);
@@ -94,7 +94,7 @@ mod tests {
             }
         }
 
-        let mut values = Values::new(b"42:foo::1.2", 0, 0);
+        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
         let access = Access::new(&mut values);
 
         assert_ok_eq!(

--- a/src/de/enum/variant/deserializer.rs
+++ b/src/de/enum/variant/deserializer.rs
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn identifier() {
-        let deserializer = Deserializer::new(Value::new(b"foo", 0, 0));
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(0, 0)));
 
         assert_ok_eq!(
             Identifier::deserialize(deserializer),
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn identifier_invalid() {
-        let deserializer = Deserializer::new(Value::new(b"\xF0\x9Ffoo", 0, 0));
+        let deserializer = Deserializer::new(Value::new(b"\xF0\x9Ffoo", Position::new(0, 0)));
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),

--- a/src/de/enum/variant/deserializer.rs
+++ b/src/de/enum/variant/deserializer.rs
@@ -238,7 +238,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_str(&self.value.parse_identifier()?)
+        visitor.visit_str(&self.value.parse_identifier()?).map_err(|mut error: Error| {
+            error.set_position(self.value.position());
+            error
+        })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -303,6 +306,45 @@ mod tests {
         assert_err_eq!(
             Identifier::deserialize(deserializer),
             Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 0))
+        );
+    }
+
+    #[test]
+    fn identifier_custom_error() {
+        #[derive(Debug)]
+        struct CustomIdentifier;
+
+        impl<'de> Deserialize<'de> for CustomIdentifier {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomIdentifierVisitor;
+
+                impl<'de> Visitor<'de> for CustomIdentifierVisitor {
+                    type Value = CustomIdentifier;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_identifier(CustomIdentifierVisitor)
+            }
+        }
+
+        let deserializer = Deserializer::new(Value::new(b"a", Position::new(1, 2))); 
+
+        assert_err_eq!(
+            CustomIdentifier::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
         );
     }
 }

--- a/src/de/enum/variant/deserializer.rs
+++ b/src/de/enum/variant/deserializer.rs
@@ -252,7 +252,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
 #[cfg(test)]
 mod tests {
     use super::Deserializer;
-    use crate::de::{error, parse::Value, Error};
+    use crate::de::{error, parse::Value, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use std::fmt;
@@ -302,7 +302,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedIdentifier, 0, 0)
+            Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 0))
         );
     }
 }

--- a/src/de/enum/variant/deserializer.rs
+++ b/src/de/enum/variant/deserializer.rs
@@ -238,10 +238,12 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_str(&self.value.parse_identifier()?).map_err(|mut error: Error| {
-            error.set_position(self.value.position());
-            error
-        })
+        visitor
+            .visit_str(&self.value.parse_identifier()?)
+            .map_err(|mut error: Error| {
+                error.set_position(self.value.position());
+                error
+            })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -340,7 +342,7 @@ mod tests {
             }
         }
 
-        let deserializer = Deserializer::new(Value::new(b"a", Position::new(1, 2))); 
+        let deserializer = Deserializer::new(Value::new(b"a", Position::new(1, 2)));
 
         assert_err_eq!(
             CustomIdentifier::deserialize(deserializer),

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -32,6 +32,39 @@ pub enum Kind {
     Custom(String),
 }
 
+impl Display for Kind {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Kind::EndOfFile => formatter.write_str("unexpected end of file"),
+            Kind::ExpectedTag => formatter.write_str("expected tag"),
+            Kind::UnexpectedTag => formatter.write_str("unexpected tag"),
+            Kind::EndOfTag => formatter.write_str("unexpected end of tag"),
+            Kind::UnexpectedValues => formatter.write_str("unexpected values"),
+            Kind::UnexpectedValue => formatter.write_str("unexpected value"),
+            Kind::EndOfValues => formatter.write_str("unexpected end of values"),
+            Kind::ExpectedBool => formatter.write_str("expected bool"),
+            Kind::ExpectedI8 => formatter.write_str("expected i8"),
+            Kind::ExpectedI16 => formatter.write_str("expected i16"),
+            Kind::ExpectedI32 => formatter.write_str("expected i32"),
+            Kind::ExpectedI64 => formatter.write_str("expected i64"),
+            Kind::ExpectedI128 => formatter.write_str("expected i128"),
+            Kind::ExpectedU8 => formatter.write_str("expected u8"),
+            Kind::ExpectedU16 => formatter.write_str("expected u16"),
+            Kind::ExpectedU32 => formatter.write_str("expected u32"),
+            Kind::ExpectedU64 => formatter.write_str("expected u64"),
+            Kind::ExpectedU128 => formatter.write_str("expected u128"),
+            Kind::ExpectedF32 => formatter.write_str("expected f32"),
+            Kind::ExpectedF64 => formatter.write_str("expected f64"),
+            Kind::ExpectedChar => formatter.write_str("expected char"),
+            Kind::ExpectedString => formatter.write_str("expected string"),
+            Kind::ExpectedUnit => formatter.write_str("expected unit value"),
+            Kind::ExpectedIdentifier => formatter.write_str("expected identifier"),
+            Kind::Io => formatter.write_str("io error"),
+            Kind::Custom(msg) => formatter.write_str(msg),
+        }
+    }
+}
+
 /// An error that may occur during deserialization.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Error {
@@ -58,8 +91,14 @@ impl de::Error for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-        todo!()
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "{} at line {} column {}",
+            self.kind,
+            self.position.line(),
+            self.position.column()
+        )
     }
 }
 
@@ -69,3 +108,226 @@ impl std::error::Error for Error {}
 ///
 /// [`Result`]: std::result::Result
 pub type Result<T> = core::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, Kind};
+    use crate::de::Position;
+
+    #[test]
+    fn end_of_file() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::EndOfFile, Position::new(1, 2))),
+            "unexpected end of file at line 1 column 2"
+        );
+    }
+
+    #[test]
+    fn expected_tag() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedTag, Position::new(2, 3))),
+            "expected tag at line 2 column 3"
+        );
+    }
+
+    #[test]
+    fn unexpected_tag() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::UnexpectedTag, Position::new(3, 4))),
+            "unexpected tag at line 3 column 4"
+        );
+    }
+
+    #[test]
+    fn end_of_tag() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::EndOfTag, Position::new(4, 5))),
+            "unexpected end of tag at line 4 column 5"
+        );
+    }
+
+    #[test]
+    fn unexpected_values() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::UnexpectedValues, Position::new(5, 6))
+            ),
+            "unexpected values at line 5 column 6"
+        );
+    }
+
+    #[test]
+    fn unexpected_value() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::UnexpectedValue, Position::new(6, 7))),
+            "unexpected value at line 6 column 7"
+        );
+    }
+
+    #[test]
+    fn end_of_values() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::EndOfValues, Position::new(7, 8))),
+            "unexpected end of values at line 7 column 8"
+        );
+    }
+
+    #[test]
+    fn expected_bool() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedBool, Position::new(8, 9))),
+            "expected bool at line 8 column 9"
+        );
+    }
+
+    #[test]
+    fn expected_i8() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedI8, Position::new(9, 10))),
+            "expected i8 at line 9 column 10"
+        );
+    }
+
+    #[test]
+    fn expected_i16() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedI16, Position::new(10, 11))),
+            "expected i16 at line 10 column 11"
+        );
+    }
+
+    #[test]
+    fn expected_i32() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedI32, Position::new(11, 12))),
+            "expected i32 at line 11 column 12"
+        );
+    }
+
+    #[test]
+    fn expected_i64() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedI64, Position::new(12, 13))),
+            "expected i64 at line 12 column 13"
+        );
+    }
+
+    #[test]
+    fn expected_i128() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedI128, Position::new(13, 14))),
+            "expected i128 at line 13 column 14"
+        );
+    }
+
+    #[test]
+    fn expected_u8() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedU8, Position::new(14, 15))),
+            "expected u8 at line 14 column 15"
+        );
+    }
+
+    #[test]
+    fn expected_u16() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedU16, Position::new(15, 16))),
+            "expected u16 at line 15 column 16"
+        );
+    }
+
+    #[test]
+    fn expected_u32() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedU32, Position::new(16, 17))),
+            "expected u32 at line 16 column 17"
+        );
+    }
+
+    #[test]
+    fn expected_u64() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedU64, Position::new(17, 18))),
+            "expected u64 at line 17 column 18"
+        );
+    }
+
+    #[test]
+    fn expected_u128() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedU128, Position::new(18, 19))),
+            "expected u128 at line 18 column 19"
+        );
+    }
+
+    #[test]
+    fn expected_f32() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedF32, Position::new(19, 20))),
+            "expected f32 at line 19 column 20"
+        );
+    }
+
+    #[test]
+    fn expected_f64() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedF64, Position::new(20, 21))),
+            "expected f64 at line 20 column 21"
+        );
+    }
+
+    #[test]
+    fn expected_char() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedChar, Position::new(21, 22))),
+            "expected char at line 21 column 22"
+        );
+    }
+
+    #[test]
+    fn expected_string() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::ExpectedString, Position::new(22, 23))
+            ),
+            "expected string at line 22 column 23"
+        );
+    }
+
+    #[test]
+    fn expected_unit() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::ExpectedUnit, Position::new(23, 24))),
+            "expected unit value at line 23 column 24"
+        );
+    }
+
+    #[test]
+    fn expected_identifier() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::ExpectedIdentifier, Position::new(24, 25))
+            ),
+            "expected identifier at line 24 column 25"
+        );
+    }
+
+    #[test]
+    fn io() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::Io, Position::new(25, 26))),
+            "io error at line 25 column 26"
+        );
+    }
+
+    #[test]
+    fn custom() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::Custom("foo".to_owned()), Position::new(26, 27))),
+            "foo at line 26 column 27"
+        );
+    }
+}

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -34,6 +34,7 @@ pub enum Kind {
     Io,
     Custom(String),
     InvalidType(String, String),
+    InvalidValue(String, String),
 }
 
 impl Display for Kind {
@@ -72,6 +73,13 @@ impl Display for Kind {
                     expected, unexpected
                 )
             }
+            Kind::InvalidValue(unexpected, expected) => {
+                write!(
+                    formatter,
+                    "invalid value: expected {}, found {}",
+                    expected, unexpected
+                )
+            }
         }
     }
 }
@@ -104,6 +112,13 @@ impl de::Error for Error {
     fn invalid_type(unexpected: Unexpected, expected: &dyn Expected) -> Self {
         Self::new(
             Kind::InvalidType(unexpected.to_string(), expected.to_string()),
+            Position::new(0, 0),
+        )
+    }
+
+    fn invalid_value(unexpected: Unexpected, expected: &dyn Expected) -> Self {
+        Self::new(
+            Kind::InvalidValue(unexpected.to_string(), expected.to_string()),
             Position::new(0, 0),
         )
     }
@@ -360,6 +375,17 @@ mod tests {
         assert_eq!(
             format!("{}", error),
             "invalid type: expected foo, found boolean `true` at line 27 column 28"
+        );
+    }
+
+    #[test]
+    fn invalid_value() {
+        let mut error = Error::invalid_value(Unexpected::Bool(true), &"foo");
+        error.set_position(Position::new(28, 29));
+
+        assert_eq!(
+            format!("{}", error),
+            "invalid value: expected foo, found boolean `true` at line 28 column 29"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,5 +1,8 @@
 use crate::de::Position;
-use serde::{de, de::{Expected, Unexpected}};
+use serde::{
+    de,
+    de::{Expected, Unexpected},
+};
 use std::{fmt, fmt::Display};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -62,7 +65,9 @@ impl Display for Kind {
             Kind::ExpectedIdentifier => formatter.write_str("expected identifier"),
             Kind::Io => formatter.write_str("io error"),
             Kind::Custom(msg) => formatter.write_str(msg),
-            Kind::InvalidType(unexpected, expected) => write!(formatter, "expected {}, found {}", expected, unexpected),
+            Kind::InvalidType(unexpected, expected) => {
+                write!(formatter, "expected {}, found {}", expected, unexpected)
+            }
         }
     }
 }
@@ -93,7 +98,10 @@ impl de::Error for Error {
     }
 
     fn invalid_type(unexpected: Unexpected, expected: &dyn Expected) -> Self {
-        Self::new(Kind::InvalidType(unexpected.to_string(), expected.to_string()), Position::new(0, 0))
+        Self::new(
+            Kind::InvalidType(unexpected.to_string(), expected.to_string()),
+            Position::new(0, 0),
+        )
     }
 }
 
@@ -121,7 +129,7 @@ mod tests {
     use super::{Error, Kind};
     use crate::de::Position;
     use serde::de::Error as SerdeError;
-    use serde::de::{Unexpected};
+    use serde::de::Unexpected;
 
     #[test]
     fn end_of_file() {
@@ -337,25 +345,16 @@ mod tests {
         let mut error = Error::custom("foo");
         error.set_position(Position::new(26, 27));
 
-        assert_eq!(
-            format!(
-                "{}",
-                error
-            ),
-            "foo at line 26 column 27"
-        );
+        assert_eq!(format!("{}", error), "foo at line 26 column 27");
     }
 
     #[test]
     fn invalid_type() {
         let mut error = Error::invalid_type(Unexpected::Bool(true), &"foo");
         error.set_position(Position::new(27, 28));
-        
+
         assert_eq!(
-            format!(
-                "{}",
-                error
-            ),
+            format!("{}", error),
             "expected foo, found boolean `true` at line 27 column 28"
         );
     }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -2,7 +2,7 @@ use crate::de::Position;
 use serde::de;
 use std::{fmt, fmt::Display};
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Kind {
     EndOfFile,
     ExpectedTag,
@@ -29,11 +29,11 @@ pub enum Kind {
     ExpectedUnit,
     ExpectedIdentifier,
     Io,
-    Custom,
+    Custom(String),
 }
 
 /// An error that may occur during deserialization.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Error {
     position: Position,
     kind: Kind,
@@ -46,16 +46,14 @@ impl Error {
 }
 
 impl de::Error for Error {
-    fn custom<T>(_msg: T) -> Self
+    fn custom<T>(msg: T) -> Self
     where
         T: Display,
     {
         // TODO: FIX THIS!
         // Need a way to provide the position to the user-provided error messages.
         // Perhaps injecting the position into the error after it is returned from user code?
-        // Also need a way to include the custom error messages. That doesn't jive with this struct
-        // being Copy.
-        Self::new(Kind::Custom, Position::new(0, 0))
+        Self::new(Kind::Custom(msg.to_string()), Position::new(0, 0))
     }
 }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -39,6 +39,7 @@ pub enum Kind {
     UnknownVariant(String, &'static [&'static str]),
     UnknownField(String, &'static [&'static str]),
     MissingField(&'static str),
+    DuplicateField(&'static str),
 }
 
 impl Display for Kind {
@@ -109,6 +110,10 @@ impl Display for Kind {
             Kind::MissingField(field) => {
                 write!(formatter, "missing field {}", field)
             }
+
+            Kind::DuplicateField(field) => {
+                write!(formatter, "duplicate field {}", field)
+            }
         }
     }
 }
@@ -175,6 +180,10 @@ impl de::Error for Error {
 
     fn missing_field(field: &'static str) -> Self {
         Self::new(Kind::MissingField(field), Position::new(0, 0))
+    }
+
+    fn duplicate_field(field: &'static str) -> Self {
+        Self::new(Kind::DuplicateField(field), Position::new(0, 0))
     }
 }
 
@@ -485,6 +494,17 @@ mod tests {
         assert_eq!(
             format!("{}", error),
             "missing field foo at line 32 column 33"
+        );
+    }
+
+    #[test]
+    fn duplicate_field() {
+        let mut error = Error::duplicate_field("foo");
+        error.set_position(Position::new(33, 34));
+
+        assert_eq!(
+            format!("{}", error),
+            "duplicate field foo at line 33 column 34"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -87,9 +87,6 @@ impl de::Error for Error {
     where
         T: Display,
     {
-        // TODO: FIX THIS!
-        // Need a way to provide the position to the user-provided error messages.
-        // Perhaps injecting the position into the error after it is returned from user code?
         Self::new(Kind::Custom(msg.to_string()), Position::new(0, 0))
     }
 }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -66,7 +66,11 @@ impl Display for Kind {
             Kind::Io => formatter.write_str("io error"),
             Kind::Custom(msg) => formatter.write_str(msg),
             Kind::InvalidType(unexpected, expected) => {
-                write!(formatter, "expected {}, found {}", expected, unexpected)
+                write!(
+                    formatter,
+                    "invalid type: expected {}, found {}",
+                    expected, unexpected
+                )
             }
         }
     }
@@ -355,7 +359,7 @@ mod tests {
 
         assert_eq!(
             format!("{}", error),
-            "expected foo, found boolean `true` at line 27 column 28"
+            "invalid type: expected foo, found boolean `true` at line 27 column 28"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -149,7 +149,7 @@ impl de::Error for Error {
     fn unknown_variant(variant: &str, expected: &'static [&'static str]) -> Self {
         Self::new(
             Kind::UnknownVariant(variant.to_owned(), expected),
-            Position::new(0, 0)
+            Position::new(0, 0),
         )
     }
 }

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -35,6 +35,7 @@ pub enum Kind {
     Custom(String),
     InvalidType(String, String),
     InvalidValue(String, String),
+    InvalidLength(usize, String),
 }
 
 impl Display for Kind {
@@ -80,6 +81,13 @@ impl Display for Kind {
                     expected, unexpected
                 )
             }
+            Kind::InvalidLength(length, expected) => {
+                write!(
+                    formatter,
+                    "invalid length {}, expected {}",
+                    length, expected
+                )
+            }
         }
     }
 }
@@ -119,6 +127,13 @@ impl de::Error for Error {
     fn invalid_value(unexpected: Unexpected, expected: &dyn Expected) -> Self {
         Self::new(
             Kind::InvalidValue(unexpected.to_string(), expected.to_string()),
+            Position::new(0, 0),
+        )
+    }
+
+    fn invalid_length(len: usize, expected: &dyn Expected) -> Self {
+        Self::new(
+            Kind::InvalidLength(len, expected.to_string()),
             Position::new(0, 0),
         )
     }
@@ -386,6 +401,17 @@ mod tests {
         assert_eq!(
             format!("{}", error),
             "invalid value: expected foo, found boolean `true` at line 28 column 29"
+        );
+    }
+
+    #[test]
+    fn invalid_length() {
+        let mut error = Error::invalid_length(42, &"foo");
+        error.set_position(Position::new(29, 30));
+
+        assert_eq!(
+            format!("{}", error),
+            "invalid length 42, expected foo at line 29 column 30"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -1,3 +1,4 @@
+use crate::de::Position;
 use serde::de;
 use std::{fmt, fmt::Display};
 
@@ -34,14 +35,13 @@ pub enum Kind {
 /// An error that may occur during deserialization.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Error {
-    line: usize,
-    column: usize,
+    position: Position,
     kind: Kind,
 }
 
 impl Error {
-    pub(super) fn new(kind: Kind, line: usize, column: usize) -> Self {
-        Self { line, column, kind }
+    pub(super) fn new(kind: Kind, position: Position) -> Self {
+        Self { position, kind }
     }
 }
 
@@ -55,7 +55,7 @@ impl de::Error for Error {
         // Perhaps injecting the position into the error after it is returned from user code?
         // Also need a way to include the custom error messages. That doesn't jive with this struct
         // being Copy.
-        Self::new(Kind::Custom, 0, 0)
+        Self::new(Kind::Custom, Position::new(0, 0))
     }
 }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -76,6 +76,10 @@ impl Error {
     pub(super) fn new(kind: Kind, position: Position) -> Self {
         Self { position, kind }
     }
+
+    pub(in crate::de) fn set_position(&mut self, position: Position) {
+        self.position = position;
+    }
 }
 
 impl de::Error for Error {
@@ -326,8 +330,20 @@ mod tests {
     #[test]
     fn custom() {
         assert_eq!(
-            format!("{}", Error::new(Kind::Custom("foo".to_owned()), Position::new(26, 27))),
+            format!(
+                "{}",
+                Error::new(Kind::Custom("foo".to_owned()), Position::new(26, 27))
+            ),
             "foo at line 26 column 27"
         );
+    }
+
+    #[test]
+    fn set_position() {
+        let mut error = Error::new(Kind::EndOfFile, Position::new(0, 0));
+
+        error.set_position(Position::new(1, 2));
+
+        assert_eq!(error.position, Position::new(1, 2));
     }
 }

--- a/src/de/map/field.rs
+++ b/src/de/map/field.rs
@@ -73,13 +73,13 @@ impl<'a, 'b, 'de> MapAccess<'de> for Access<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::parse::Tag;
+    use crate::de::{parse::Tag, Position};
     use claim::{assert_none, assert_ok, assert_ok_eq, assert_some_eq};
     use serde::de::MapAccess;
 
     #[test]
     fn next_key_and_value() {
-        let mut tag = Tag::new(b"foo:42;", 0, 0);
+        let mut tag = Tag::new(b"foo:42;", Position::new(0, 0));
         let mut access = Access::new(&mut tag);
 
         assert_some_eq!(assert_ok!(access.next_key::<String>()), "foo".to_owned());
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn multiple_keys_and_values() {
-        let mut tag = Tag::new(b"foo:42;bar:100", 0, 0);
+        let mut tag = Tag::new(b"foo:42;bar:100", Position::new(0, 0));
         let mut access = Access::new(&mut tag);
 
         assert_some_eq!(assert_ok!(access.next_key::<String>()), "foo".to_owned());
@@ -101,7 +101,7 @@ mod tests {
     #[should_panic]
     fn next_value_without_next_key() {
         // Should panic if `next_value()` is called before `next_key()`.
-        let mut tag = Tag::new(b"42;", 0, 0);
+        let mut tag = Tag::new(b"42;", Position::new(0, 0));
         let mut access = Access::new(&mut tag);
 
         let _ = access.next_value::<u64>();
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn next_key_none() {
-        let mut tag = Tag::new(b"", 0, 0);
+        let mut tag = Tag::new(b"", Position::new(0, 0));
         assert_ok!(tag.next());
         let mut access = Access::new(&mut tag);
 
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn next_entry() {
-        let mut tag = Tag::new(b"foo:42;", 0, 0);
+        let mut tag = Tag::new(b"foo:42;", Position::new(0, 0));
         let mut access = Access::new(&mut tag);
 
         assert_some_eq!(
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn multiple_entries() {
-        let mut tag = Tag::new(b"foo:42;bar:100;", 0, 0);
+        let mut tag = Tag::new(b"foo:42;bar:100;", Position::new(0, 0));
         let mut access = Access::new(&mut tag);
 
         assert_some_eq!(
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn next_entry_none() {
-        let mut tag = Tag::new(b"", 0, 0);
+        let mut tag = Tag::new(b"", Position::new(0, 0));
         assert_ok!(tag.next());
         let mut access = Access::new(&mut tag);
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -23,12 +23,14 @@ mod r#enum;
 mod error;
 mod map;
 mod parse;
+mod position;
 mod seq;
 mod r#struct;
 mod tuple;
 
 pub use error::{Error, Result};
 
+use position::Position;
 use serde::{
     de,
     de::{DeserializeOwned, Visitor},
@@ -515,7 +517,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{error, Deserializer, Error};
+    use super::{error, Deserializer, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use serde_bytes::ByteBuf;
@@ -542,7 +544,7 @@ mod tests {
 
         assert_err_eq!(
             bool::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedBool, 0, 1)
+            Error::new(error::Kind::ExpectedBool, Position::new(0, 1))
         );
     }
 
@@ -573,7 +575,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -583,7 +585,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -593,7 +595,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -624,7 +626,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 1)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 1))
         );
     }
 
@@ -634,7 +636,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 1)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 1))
         );
     }
 
@@ -644,7 +646,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 1)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 1))
         );
     }
 
@@ -675,7 +677,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -685,7 +687,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -695,7 +697,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -726,7 +728,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 1)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 1))
         );
     }
 
@@ -736,7 +738,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 1)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 1))
         );
     }
 
@@ -746,7 +748,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 1)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 1))
         );
     }
 
@@ -778,7 +780,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 1)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 1))
         );
     }
 
@@ -789,7 +791,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 1)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 1))
         );
     }
 
@@ -799,7 +801,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 1)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 1))
         );
     }
 
@@ -823,7 +825,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU8, 0, 1)
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 1))
         );
     }
 
@@ -833,7 +835,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU8, 0, 1)
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 1))
         );
     }
 
@@ -857,7 +859,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU16, 0, 1)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 1))
         );
     }
 
@@ -867,7 +869,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU16, 0, 1)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 1))
         );
     }
 
@@ -891,7 +893,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU32, 0, 1)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 1))
         );
     }
 
@@ -901,7 +903,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU32, 0, 1)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 1))
         );
     }
 
@@ -925,7 +927,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU64, 0, 1)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 1))
         );
     }
 
@@ -935,7 +937,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU64, 0, 1)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 1))
         );
     }
 
@@ -960,7 +962,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU128, 0, 1)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 1))
         );
     }
 
@@ -970,7 +972,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedU128, 0, 1)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 1))
         );
     }
 
@@ -1015,7 +1017,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedF32, 0, 1)
+            Error::new(error::Kind::ExpectedF32, Position::new(0, 1))
         );
     }
 
@@ -1060,7 +1062,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedF64, 0, 1)
+            Error::new(error::Kind::ExpectedF64, Position::new(0, 1))
         );
     }
 
@@ -1077,7 +1079,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(&mut deserializer),
-            Error::new(error::Kind::EndOfFile, 0, 0)
+            Error::new(error::Kind::EndOfFile, Position::new(0, 0))
         );
     }
 
@@ -1087,7 +1089,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 0, 3)
+            Error::new(error::Kind::UnexpectedTag, Position::new(0, 3))
         );
     }
 
@@ -1097,7 +1099,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 3)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 3))
         );
     }
 
@@ -1107,7 +1109,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 3)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 3))
         );
     }
 
@@ -1117,7 +1119,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedChar, 0, 1),
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 1)),
         );
     }
 
@@ -1134,7 +1136,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 0, 5)
+            Error::new(error::Kind::UnexpectedTag, Position::new(0, 5))
         );
     }
 
@@ -1144,7 +1146,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -1154,7 +1156,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1164,7 +1166,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedString, 0, 1),
+            Error::new(error::Kind::ExpectedString, Position::new(0, 1)),
         );
     }
 
@@ -1181,7 +1183,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 0, 5)
+            Error::new(error::Kind::UnexpectedTag, Position::new(0, 5))
         );
     }
 
@@ -1191,7 +1193,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -1201,7 +1203,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1239,7 +1241,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 1)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 1))
         );
     }
 
@@ -1249,7 +1251,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1259,7 +1261,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 1, 0)
+            Error::new(error::Kind::UnexpectedValues, Position::new(1, 0))
         );
     }
 
@@ -1269,7 +1271,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 2)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 2))
         );
     }
 
@@ -1290,7 +1292,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 1)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 1))
         );
     }
 
@@ -1302,7 +1304,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1314,7 +1316,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 1, 0)
+            Error::new(error::Kind::UnexpectedValues, Position::new(1, 0))
         );
     }
 
@@ -1326,7 +1328,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 2)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 2))
         );
     }
 
@@ -1385,7 +1387,7 @@ mod tests {
 
         assert_err_eq!(
             <(String, u64, ())>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1395,7 +1397,7 @@ mod tests {
 
         assert_err_eq!(
             <(String, u64, (), f64)>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 1, 0)
+            Error::new(error::Kind::UnexpectedValues, Position::new(1, 0))
         );
     }
 
@@ -1405,7 +1407,7 @@ mod tests {
 
         assert_err_eq!(
             <(String, u64, (), f64)>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1455,7 +1457,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1467,7 +1469,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 1, 0)
+            Error::new(error::Kind::UnexpectedValues, Position::new(1, 0))
         );
     }
 
@@ -1479,7 +1481,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1639,7 +1641,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1653,7 +1655,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 9)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
         );
     }
 
@@ -1667,7 +1669,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1695,7 +1697,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 12)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 12))
         );
     }
 
@@ -1709,7 +1711,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 12)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 12))
         );
     }
 
@@ -1723,7 +1725,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1751,7 +1753,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 21)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 21))
         );
     }
 
@@ -1765,7 +1767,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 21)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 21))
         );
     }
 
@@ -1779,7 +1781,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 1, 0)
+            Error::new(error::Kind::UnexpectedTag, Position::new(1, 0))
         );
     }
 
@@ -1838,7 +1840,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedTag, 0, 5)
+            Error::new(error::Kind::UnexpectedTag, Position::new(0, 5))
         );
     }
 
@@ -1848,7 +1850,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -1858,7 +1860,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1868,7 +1870,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedIdentifier, 0, 1),
+            Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 1)),
         );
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -94,10 +94,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_bool()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_bool(parsed)
+        visitor.visit_bool(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
@@ -108,10 +112,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_i8()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_i8(parsed)
+        visitor.visit_i8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
@@ -122,10 +130,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_i16()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_i16(parsed)
+        visitor.visit_i16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
@@ -136,10 +148,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_i32()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_i32(parsed)
+        visitor.visit_i32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
@@ -150,10 +166,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_i64()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_i64(parsed)
+        visitor.visit_i64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -165,10 +185,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_i128()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_i128(parsed)
+        visitor.visit_i128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -179,10 +203,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_u8()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_u8(parsed)
+        visitor.visit_u8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
@@ -193,10 +221,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_u16()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_u16(parsed)
+        visitor.visit_u16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
@@ -207,10 +239,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_u32()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_u32(parsed)
+        visitor.visit_u32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
@@ -221,10 +257,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_u64()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_u64(parsed)
+        visitor.visit_u64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -236,10 +276,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_u128()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_u128(parsed)
+        visitor.visit_u128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -250,10 +294,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_f32()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_f32(parsed)
+        visitor.visit_f32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
@@ -264,10 +312,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_f64()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_f64(parsed)
+        visitor.visit_f64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
@@ -278,10 +330,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_char()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_char(parsed)
+        visitor.visit_char(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -293,10 +349,14 @@ where
         let value = values.next()?;
         // Parsed string must be owned, since it removes escaping and comments.
         let parsed = value.parse_string()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
@@ -307,10 +367,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_string()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_string(parsed)
+        visitor.visit_string(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
@@ -322,10 +386,14 @@ where
         let value = values.next()?;
         // Parsed bytes must be owned, since it removes escaping and comments.
         let parsed = value.parse_byte_buf();
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_bytes(&parsed)
+        visitor.visit_bytes(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -336,10 +404,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         let parsed = value.parse_byte_buf();
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_byte_buf(parsed)
+        visitor.visit_byte_buf(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
@@ -361,10 +433,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         value.parse_unit()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -375,10 +451,14 @@ where
         let mut values = tag.next()?;
         let value = values.next()?;
         value.parse_unit()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -478,10 +558,14 @@ where
         let value = values.next()?;
         // Parsed string must be owned, since it removes escaping and comments.
         let parsed = value.parse_identifier()?;
+        let value_position = value.position();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
         self.tags.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -549,6 +633,45 @@ mod tests {
     }
 
     #[test]
+    fn bool_custom_error() {
+        #[derive(Debug)]
+        struct CustomBool;
+
+        impl<'de> Deserialize<'de> for CustomBool {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomBoolVisitor;
+
+                impl<'de> Visitor<'de> for CustomBoolVisitor {
+                    type Value = CustomBool;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_bool(CustomBoolVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#true;".as_slice());
+
+        assert_err_eq!(
+            CustomBool::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn i8_positive() {
         let mut deserializer = Deserializer::new(b"#42;".as_slice());
 
@@ -596,6 +719,45 @@ mod tests {
         assert_err_eq!(
             i8::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn i8_custom_error() {
+        #[derive(Debug)]
+        struct CustomI8;
+
+        impl<'de> Deserialize<'de> for CustomI8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI8Visitor;
+
+                impl<'de> Visitor<'de> for CustomI8Visitor {
+                    type Value = CustomI8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i8<E>(self, _value: i8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i8(CustomI8Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomI8::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -651,6 +813,45 @@ mod tests {
     }
 
     #[test]
+    fn i16_custom_error() {
+        #[derive(Debug)]
+        struct CustomI16;
+
+        impl<'de> Deserialize<'de> for CustomI16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI16Visitor;
+
+                impl<'de> Visitor<'de> for CustomI16Visitor {
+                    type Value = CustomI16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i16<E>(self, _value: i16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i16(CustomI16Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomI16::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn i32_positive() {
         let mut deserializer = Deserializer::new(b"#42;".as_slice());
 
@@ -676,8 +877,8 @@ mod tests {
         let mut deserializer = Deserializer::new(b"#2147483648;".as_slice());
 
         assert_err_eq!(
-            i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
+            i32::deserialize(&mut deserializer),
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 1))
         );
     }
 
@@ -686,8 +887,8 @@ mod tests {
         let mut deserializer = Deserializer::new(b"#-2147483649;".as_slice());
 
         assert_err_eq!(
-            i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
+            i32::deserialize(&mut deserializer),
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 1))
         );
     }
 
@@ -696,8 +897,47 @@ mod tests {
         let mut deserializer = Deserializer::new(b"#invalid;".as_slice());
 
         assert_err_eq!(
-            i8::deserialize(&mut deserializer),
-            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
+            i32::deserialize(&mut deserializer),
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn i32_custom_error() {
+        #[derive(Debug)]
+        struct CustomI32;
+
+        impl<'de> Deserialize<'de> for CustomI32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI32Visitor;
+
+                impl<'de> Visitor<'de> for CustomI32Visitor {
+                    type Value = CustomI32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i32<E>(self, _value: i32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i32(CustomI32Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomI32::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -749,6 +989,45 @@ mod tests {
         assert_err_eq!(
             i64::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedI64, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn i64_custom_error() {
+        #[derive(Debug)]
+        struct CustomI64;
+
+        impl<'de> Deserialize<'de> for CustomI64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI64Visitor;
+
+                impl<'de> Visitor<'de> for CustomI64Visitor {
+                    type Value = CustomI64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i64(CustomI64Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomI64::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -806,6 +1085,45 @@ mod tests {
     }
 
     #[test]
+    fn i128_custom_error() {
+        #[derive(Debug)]
+        struct CustomI128;
+
+        impl<'de> Deserialize<'de> for CustomI128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI128Visitor;
+
+                impl<'de> Visitor<'de> for CustomI128Visitor {
+                    type Value = CustomI128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i128<E>(self, _value: i128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i128(CustomI128Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomI128::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u8() {
         let mut deserializer = Deserializer::new(b"#42;".as_slice());
 
@@ -836,6 +1154,45 @@ mod tests {
         assert_err_eq!(
             u8::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedU8, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn u8_custom_error() {
+        #[derive(Debug)]
+        struct CustomU8;
+
+        impl<'de> Deserialize<'de> for CustomU8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU8Visitor;
+
+                impl<'de> Visitor<'de> for CustomU8Visitor {
+                    type Value = CustomU8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u8<E>(self, _value: u8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u8(CustomU8Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomU8::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -874,6 +1231,45 @@ mod tests {
     }
 
     #[test]
+    fn u16_custom_error() {
+        #[derive(Debug)]
+        struct CustomU16;
+
+        impl<'de> Deserialize<'de> for CustomU16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU16Visitor;
+
+                impl<'de> Visitor<'de> for CustomU16Visitor {
+                    type Value = CustomU16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u16<E>(self, _value: u16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u16(CustomU16Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomU16::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u32() {
         let mut deserializer = Deserializer::new(b"#42;".as_slice());
 
@@ -904,6 +1300,45 @@ mod tests {
         assert_err_eq!(
             u32::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedU32, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn u32_custom_error() {
+        #[derive(Debug)]
+        struct CustomU32;
+
+        impl<'de> Deserialize<'de> for CustomU32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU32Visitor;
+
+                impl<'de> Visitor<'de> for CustomU32Visitor {
+                    type Value = CustomU32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u32<E>(self, _value: u32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u32(CustomU32Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomU32::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -942,6 +1377,45 @@ mod tests {
     }
 
     #[test]
+    fn u64_custom_error() {
+        #[derive(Debug)]
+        struct CustomU64;
+
+        impl<'de> Deserialize<'de> for CustomU64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU64Visitor;
+
+                impl<'de> Visitor<'de> for CustomU64Visitor {
+                    type Value = CustomU64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u64(CustomU64Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomU64::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u128() {
         let mut deserializer = Deserializer::new(b"#42;".as_slice());
 
@@ -973,6 +1447,45 @@ mod tests {
         assert_err_eq!(
             u128::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedU128, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn u128_custom_error() {
+        #[derive(Debug)]
+        struct CustomU128;
+
+        impl<'de> Deserialize<'de> for CustomU128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU128Visitor;
+
+                impl<'de> Visitor<'de> for CustomU128Visitor {
+                    type Value = CustomU128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u128<E>(self, _value: u128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u128(CustomU128Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomU128::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1022,6 +1535,45 @@ mod tests {
     }
 
     #[test]
+    fn f32_custom_error() {
+        #[derive(Debug)]
+        struct CustomF32;
+
+        impl<'de> Deserialize<'de> for CustomF32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF32Visitor;
+
+                impl<'de> Visitor<'de> for CustomF32Visitor {
+                    type Value = CustomF32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f32<E>(self, _value: f32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f32(CustomF32Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomF32::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn f64_positive() {
         let mut deserializer = Deserializer::new(b"#42.9;".as_slice());
 
@@ -1063,6 +1615,45 @@ mod tests {
         assert_err_eq!(
             f64::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedF64, Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn f64_custom_error() {
+        #[derive(Debug)]
+        struct CustomF64;
+
+        impl<'de> Deserialize<'de> for CustomF64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF64Visitor;
+
+                impl<'de> Visitor<'de> for CustomF64Visitor {
+                    type Value = CustomF64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f64(CustomF64Visitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#42;".as_slice());
+
+        assert_err_eq!(
+            CustomF64::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1124,6 +1715,45 @@ mod tests {
     }
 
     #[test]
+    fn char_custom_error() {
+        #[derive(Debug)]
+        struct CustomChar;
+
+        impl<'de> Deserialize<'de> for CustomChar {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomCharVisitor;
+
+                impl<'de> Visitor<'de> for CustomCharVisitor {
+                    type Value = CustomChar;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_char<E>(self, _value: char) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_char(CustomCharVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#a;".as_slice());
+
+        assert_err_eq!(
+            CustomChar::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn string() {
         let mut deserializer = Deserializer::new(b"#foo;".as_slice());
 
@@ -1171,6 +1801,45 @@ mod tests {
     }
 
     #[test]
+    fn string_custom_error() {
+        #[derive(Debug)]
+        struct CustomString;
+
+        impl<'de> Deserialize<'de> for CustomString {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomStringVisitor;
+
+                impl<'de> Visitor<'de> for CustomStringVisitor {
+                    type Value = CustomString;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_string(CustomStringVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#a;".as_slice());
+
+        assert_err_eq!(
+            CustomString::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn byte_buf() {
         let mut deserializer = Deserializer::new(b"#foo;".as_slice());
 
@@ -1212,6 +1881,45 @@ mod tests {
         let mut deserializer = Deserializer::new(b"#\xF0\x9Ffoo;\n".as_slice());
 
         assert_ok_eq!(ByteBuf::deserialize(&mut deserializer), b"\xF0\x9Ffoo",);
+    }
+
+    #[test]
+    fn byte_buf_custom_error() {
+        #[derive(Debug)]
+        struct CustomByteBuf;
+
+        impl<'de> Deserialize<'de> for CustomByteBuf {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomByteBufVisitor;
+
+                impl<'de> Visitor<'de> for CustomByteBufVisitor {
+                    type Value = CustomByteBuf;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_byte_buf<E>(self, _value: Vec<u8>) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_byte_buf(CustomByteBufVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#a;".as_slice());
+
+        assert_err_eq!(
+            CustomByteBuf::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
     }
 
     #[test]
@@ -1276,6 +1984,45 @@ mod tests {
     }
 
     #[test]
+    fn unit_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnit;
+
+        impl<'de> Deserialize<'de> for CustomUnit {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitVisitor {
+                    type Value = CustomUnit;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit(CustomUnitVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#;".as_slice());
+
+        assert_err_eq!(
+            CustomUnit::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn unit_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
@@ -1329,6 +2076,45 @@ mod tests {
         assert_err_eq!(
             Unit::deserialize(&mut deserializer),
             Error::new(error::Kind::UnexpectedValue, Position::new(0, 2))
+        );
+    }
+
+    #[test]
+    fn unit_struct_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnitStruct;
+
+        impl<'de> Deserialize<'de> for CustomUnitStruct {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitStructVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitStructVisitor {
+                    type Value = CustomUnitStruct;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit_struct("CustomUnitStruct", CustomUnitStructVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#;".as_slice());
+
+        assert_err_eq!(
+            CustomUnitStruct::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1871,6 +2657,45 @@ mod tests {
         assert_err_eq!(
             Identifier::deserialize(&mut deserializer),
             Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 1)),
+        );
+    }
+
+    #[test]
+    fn identifier_custom_error() {
+        #[derive(Debug)]
+        struct CustomIdentifier;
+
+        impl<'de> Deserialize<'de> for CustomIdentifier {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomIdentifierVisitor;
+
+                impl<'de> Visitor<'de> for CustomIdentifierVisitor {
+                    type Value = CustomIdentifier;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_identifier(CustomIdentifierVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"#a;".as_slice());
+
+        assert_err_eq!(
+            CustomIdentifier::deserialize(&mut deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 }

--- a/src/de/parse/tag.rs
+++ b/src/de/parse/tag.rs
@@ -94,10 +94,10 @@ impl<'a> Tag<'a> {
             first_values: true,
 
             started_byte_index: 0,
-            started_position: Position::new(position.line, position.column + 1),
+            started_position: position.increment_column(),
 
             current_byte_index: 0,
-            current_position: Position::new(position.line, position.column + 1),
+            current_position: position.increment_column(),
 
             origin_position: position,
 
@@ -165,9 +165,9 @@ impl<'a> Tag<'a> {
                 }
                 last_byte_newline = matches!(byte, b'\n');
                 if last_byte_newline {
-                    self.current_position = Position::new(self.current_position.line + 1, 0);
+                    self.current_position = self.current_position.increment_line();
                 } else {
-                    self.current_position = Position::new(self.current_position.line, self.current_position.column + 1);
+                    self.current_position = self.current_position.increment_column();
                 }
                 self.current_byte_index += 1;
 
@@ -203,9 +203,9 @@ impl<'a> Tag<'a> {
 
     pub(in crate::de) fn reset(&mut self) {
         self.first_values = true;
-        self.started_position = Position::new(self.origin_position.line, self.origin_position.column + 1);
+        self.started_position = self.origin_position.increment_column();
         self.current_byte_index = 0;
-        self.current_position = Position::new(self.origin_position.line, self.origin_position.column + 1);
+        self.current_position = self.origin_position.increment_column();
     }
 
     // SAFETY: `values` must reference the same buffer referenced by this tag. In other words,
@@ -224,9 +224,9 @@ impl<'a> Tag<'a> {
                     current_position,
                 ));
             } else if matches!(byte, b'\n') {
-                current_position = Position::new(current_position.line + 1, 0);
+                current_position = current_position.increment_line();
             } else {
-                current_position = Position::new(current_position.line, current_position.column + 1);
+                current_position = current_position.increment_column();
             }
         }
         Ok(())

--- a/src/de/parse/tag.rs
+++ b/src/de/parse/tag.rs
@@ -193,10 +193,7 @@ impl<'a> Tag<'a> {
                         self.started_position,
                     ));
                 }
-                return Err(Error::new(
-                    error::Kind::EndOfTag,
-                    self.current_position,
-                ));
+                return Err(Error::new(error::Kind::EndOfTag, self.current_position));
             }
         }
     }
@@ -219,10 +216,7 @@ impl<'a> Tag<'a> {
         // SAFETY: self.current_byte_index is guaranteed to be within the bounds of self.bytes.
         for byte in unsafe { self.bytes.get_unchecked(self.current_byte_index..) } {
             if !byte.is_ascii_whitespace() {
-                return Err(Error::new(
-                    error::Kind::UnexpectedValues,
-                    current_position,
-                ));
+                return Err(Error::new(error::Kind::UnexpectedValues, current_position));
             } else if matches!(byte, b'\n') {
                 current_position = current_position.increment_line();
             } else {
@@ -260,7 +254,10 @@ mod tests {
         let mut tag = Tag::new(b"", Position::new(0, 0));
 
         assert_ok_eq!(tag.next(), Values::new(b"", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 1)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(0, 1))
+        );
     }
 
     #[test]
@@ -268,7 +265,10 @@ mod tests {
         let mut tag = Tag::new(b"foo;\n", Position::new(0, 0));
 
         assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
     }
 
     #[test]
@@ -276,7 +276,10 @@ mod tests {
         let mut tag = Tag::new(b"foo:bar:baz;\n", Position::new(0, 0));
 
         assert_ok_eq!(tag.next(), Values::new(b"foo:bar:baz", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
     }
 
     #[test]
@@ -285,7 +288,10 @@ mod tests {
 
         assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
         assert_ok_eq!(tag.next(), Values::new(b"bar", Position::new(0, 5)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 9)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(0, 9))
+        );
     }
 
     #[test]
@@ -293,24 +299,39 @@ mod tests {
         let mut tag = Tag::new(b"foo\\;bar;", Position::new(0, 0));
 
         assert_ok_eq!(tag.next(), Values::new(b"foo\\;bar", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 10)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(0, 10))
+        );
     }
 
     #[test]
     fn comment() {
         let mut tag = Tag::new(b"foo: //comment;\nbar;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo: //comment;\nbar", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(2, 0)));
+        assert_ok_eq!(
+            tag.next(),
+            Values::new(b"foo: //comment;\nbar", Position::new(0, 1))
+        );
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(2, 0))
+        );
     }
 
     #[test]
     fn escaped_comment() {
         let mut tag = Tag::new(b"foo: \\/\\/comment;\nbar;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo: \\/\\/comment", Position::new(0, 1)));
+        assert_ok_eq!(
+            tag.next(),
+            Values::new(b"foo: \\/\\/comment", Position::new(0, 1))
+        );
         assert_ok_eq!(tag.next(), Values::new(b"\nbar", Position::new(0, 18)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(2, 0)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(2, 0))
+        );
     }
 
     #[test]
@@ -318,7 +339,10 @@ mod tests {
         let mut tag = Tag::new(b"foo\n", Position::new(0, 0));
 
         assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
-        assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
     }
 
     #[test]
@@ -370,8 +394,14 @@ mod tests {
         let stored = tag.into_stored();
         let mut unstored_tag = unsafe { stored.into_tag() };
 
-        assert_ok_eq!(unstored_tag.next(), Values::new(b"foo", Position::new(0, 1)));
-        assert_err_eq!(unstored_tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 5)));
+        assert_ok_eq!(
+            unstored_tag.next(),
+            Values::new(b"foo", Position::new(0, 1))
+        );
+        assert_err_eq!(
+            unstored_tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(0, 5))
+        );
     }
 
     #[test]
@@ -382,8 +412,14 @@ mod tests {
         let stored = tag.into_stored();
         let mut unstored_tag = unsafe { stored.into_tag() };
 
-        assert_ok_eq!(unstored_tag.next(), Values::new(b"bar", Position::new(0, 5)));
-        assert_err_eq!(unstored_tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 9)));
+        assert_ok_eq!(
+            unstored_tag.next(),
+            Values::new(b"bar", Position::new(0, 5))
+        );
+        assert_err_eq!(
+            unstored_tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(0, 9))
+        );
     }
 
     #[test]

--- a/src/de/parse/tag.rs
+++ b/src/de/parse/tag.rs
@@ -24,11 +24,9 @@ pub(in crate::de) struct StoredTag {
     first_values: bool,
 
     current_byte_index: usize,
-    current_line: usize,
-    current_column: usize,
+    current_position: Position,
 
-    origin_line: usize,
-    origin_column: usize,
+    origin_position: Position,
 
     revisit: Option<StoredValues>,
 }
@@ -48,27 +46,20 @@ impl StoredTag {
             first_values: self.first_values,
 
             started_byte_index: self.current_byte_index,
-            started_line: self.current_line,
-            started_column: self.current_column,
+            started_position: self.current_position,
 
             current_byte_index: self.current_byte_index,
-            current_line: self.current_line,
-            current_column: self.current_column,
+            current_position: self.current_position,
 
-            origin_line: self.origin_line,
-            origin_column: self.origin_column,
+            origin_position: self.origin_position,
 
-            // The revisit is guaranteed to have the same lifetime as the containing `Tag`.
+            // SAFETY: The revisit is guaranteed to have the same lifetime as the containing `Tag`.
             revisit: unsafe { self.revisit.map(|stored| stored.into_values()) },
         }
     }
 
-    pub(in crate::de) fn origin_line(&self) -> usize {
-        self.origin_line
-    }
-
-    pub(in crate::de) fn origin_column(&self) -> usize {
-        self.origin_column
+    pub(in crate::de) fn origin_position(&self) -> Position {
+        self.origin_position
     }
 }
 
@@ -83,21 +74,18 @@ pub(in crate::de) struct Tag<'a> {
 
     started_byte_index: usize,
     // The position includes the implicit leading `#`. In reality, `bytes` starts at `column + 1`.
-    started_line: usize,
-    started_column: usize,
+    started_position: Position,
 
     current_byte_index: usize,
-    current_line: usize,
-    current_column: usize,
+    current_position: Position,
 
-    origin_line: usize,
-    origin_column: usize,
+    origin_position: Position,
 
     revisit: Option<Values<'a>>,
 }
 
 impl<'a> Tag<'a> {
-    pub(in crate::de) fn new(bytes: &'a [u8], line: usize, column: usize) -> Self {
+    pub(in crate::de) fn new(bytes: &'a [u8], position: Position) -> Self {
         Self {
             bytes,
 
@@ -106,15 +94,12 @@ impl<'a> Tag<'a> {
             first_values: true,
 
             started_byte_index: 0,
-            started_line: line,
-            started_column: column + 1,
+            started_position: Position::new(position.line, position.column + 1),
 
             current_byte_index: 0,
-            current_line: line,
-            current_column: column + 1,
+            current_position: Position::new(position.line, position.column + 1),
 
-            origin_line: line,
-            origin_column: column,
+            origin_position: position,
 
             revisit: None,
         }
@@ -127,8 +112,7 @@ impl<'a> Tag<'a> {
 
         let mut values = None;
         self.started_byte_index = self.current_byte_index;
-        self.started_line = self.current_line;
-        self.started_column = self.current_column;
+        self.started_position = self.current_position;
         let mut encountered_non_whitespace = false;
         let mut last_byte_newline = false;
         loop {
@@ -156,8 +140,7 @@ impl<'a> Tag<'a> {
                                             self.started_byte_index..self.current_byte_index,
                                         )
                                     },
-                                    self.started_line,
-                                    self.started_column,
+                                    self.started_position,
                                 ));
                             }
                             b'\\' => {
@@ -182,10 +165,9 @@ impl<'a> Tag<'a> {
                 }
                 last_byte_newline = matches!(byte, b'\n');
                 if last_byte_newline {
-                    self.current_line += 1;
-                    self.current_column = 0;
+                    self.current_position = Position::new(self.current_position.line + 1, 0);
                 } else {
-                    self.current_column += 1;
+                    self.current_position = Position::new(self.current_position.line, self.current_position.column + 1);
                 }
                 self.current_byte_index += 1;
 
@@ -208,14 +190,12 @@ impl<'a> Tag<'a> {
                             self.bytes
                                 .get_unchecked(self.started_byte_index..ending_byte_index)
                         },
-                        self.started_line,
-                        self.started_column,
+                        self.started_position,
                     ));
                 }
                 return Err(Error::new(
                     error::Kind::EndOfTag,
-                    Position::new(self.current_line,
-                    self.current_column),
+                    self.current_position,
                 ));
             }
         }
@@ -223,11 +203,9 @@ impl<'a> Tag<'a> {
 
     pub(in crate::de) fn reset(&mut self) {
         self.first_values = true;
-        self.started_line = self.origin_line;
-        self.started_column = self.origin_column + 1;
+        self.started_position = Position::new(self.origin_position.line, self.origin_position.column + 1);
         self.current_byte_index = 0;
-        self.current_line = self.origin_line;
-        self.current_column = self.origin_column + 1;
+        self.current_position = Position::new(self.origin_position.line, self.origin_position.column + 1);
     }
 
     // SAFETY: `values` must reference the same buffer referenced by this tag. In other words,
@@ -237,21 +215,18 @@ impl<'a> Tag<'a> {
     }
 
     pub(in crate::de) fn assert_exhausted(&self) -> Result<()> {
-        let mut current_line = self.current_line;
-        let mut current_column = self.current_column;
+        let mut current_position = self.current_position;
         // SAFETY: self.current_byte_index is guaranteed to be within the bounds of self.bytes.
         for byte in unsafe { self.bytes.get_unchecked(self.current_byte_index..) } {
             if !byte.is_ascii_whitespace() {
                 return Err(Error::new(
                     error::Kind::UnexpectedValues,
-                    Position::new(current_line,
-                    current_column),
+                    current_position,
                 ));
             } else if matches!(byte, b'\n') {
-                current_line += 1;
-                current_column = 0;
+                current_position = Position::new(current_position.line + 1, 0);
             } else {
-                current_column += 1;
+                current_position = Position::new(current_position.line, current_position.column + 1);
             }
         }
         Ok(())
@@ -265,11 +240,9 @@ impl<'a> Tag<'a> {
             first_values: self.first_values,
 
             current_byte_index: self.current_byte_index,
-            current_line: self.current_line,
-            current_column: self.current_column,
+            current_position: self.current_position,
 
-            origin_line: self.origin_line,
-            origin_column: self.origin_column,
+            origin_position: self.origin_position,
 
             revisit: self.revisit.map(|values| values.into_stored()),
         }
@@ -284,94 +257,94 @@ mod tests {
 
     #[test]
     fn empty() {
-        let mut tag = Tag::new(b"", 0, 0);
+        let mut tag = Tag::new(b"", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 1)));
     }
 
     #[test]
     fn finds_single_values() {
-        let mut tag = Tag::new(b"foo;\n", 0, 0);
+        let mut tag = Tag::new(b"foo;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
     }
 
     #[test]
     fn finds_single_values_with_splitting_colons() {
-        let mut tag = Tag::new(b"foo:bar:baz;\n", 0, 0);
+        let mut tag = Tag::new(b"foo:bar:baz;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo:bar:baz", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo:bar:baz", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
     }
 
     #[test]
     fn finds_multiple_values() {
-        let mut tag = Tag::new(b"foo;bar;", 0, 0);
+        let mut tag = Tag::new(b"foo;bar;", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo", 0, 1));
-        assert_ok_eq!(tag.next(), Values::new(b"bar", 0, 5));
+        assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
+        assert_ok_eq!(tag.next(), Values::new(b"bar", Position::new(0, 5)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 9)));
     }
 
     #[test]
     fn escaped_colon() {
-        let mut tag = Tag::new(b"foo\\;bar;", 0, 0);
+        let mut tag = Tag::new(b"foo\\;bar;", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo\\;bar", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo\\;bar", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 10)));
     }
 
     #[test]
     fn comment() {
-        let mut tag = Tag::new(b"foo: //comment;\nbar;\n", 0, 0);
+        let mut tag = Tag::new(b"foo: //comment;\nbar;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo: //comment;\nbar", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo: //comment;\nbar", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(2, 0)));
     }
 
     #[test]
     fn escaped_comment() {
-        let mut tag = Tag::new(b"foo: \\/\\/comment;\nbar;\n", 0, 0);
+        let mut tag = Tag::new(b"foo: \\/\\/comment;\nbar;\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo: \\/\\/comment", 0, 1));
-        assert_ok_eq!(tag.next(), Values::new(b"\nbar", 0, 18));
+        assert_ok_eq!(tag.next(), Values::new(b"foo: \\/\\/comment", Position::new(0, 1)));
+        assert_ok_eq!(tag.next(), Values::new(b"\nbar", Position::new(0, 18)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(2, 0)));
     }
 
     #[test]
     fn no_closing_semicolon() {
-        let mut tag = Tag::new(b"foo\n", 0, 0);
+        let mut tag = Tag::new(b"foo\n", Position::new(0, 0));
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
         assert_err_eq!(tag.next(), Error::new(error::Kind::EndOfTag, Position::new(1, 0)));
     }
 
     #[test]
     fn reset() {
-        let mut tag = Tag::new(b"foo;\n", 0, 0);
+        let mut tag = Tag::new(b"foo;\n", Position::new(0, 0));
 
         assert_ok!(tag.next());
         assert_ok!(tag.assert_exhausted());
 
         tag.reset();
 
-        assert_ok_eq!(tag.next(), Values::new(b"foo", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
     }
 
     #[test]
     fn revisit() {
-        let mut tag = Tag::new(b"foo;", 0, 0);
+        let mut tag = Tag::new(b"foo;", Position::new(0, 0));
 
         let values = assert_ok!(tag.next());
         unsafe { tag.revisit(values) };
-        assert_ok_eq!(tag.next(), Values::new(b"foo", 0, 1));
+        assert_ok_eq!(tag.next(), Values::new(b"foo", Position::new(0, 1)));
     }
 
     #[test]
     fn exhausted() {
-        let mut tag = Tag::new(b"foo;\n", 0, 0);
+        let mut tag = Tag::new(b"foo;\n", Position::new(0, 0));
 
         assert_ok!(tag.next());
 
@@ -380,7 +353,7 @@ mod tests {
 
     #[test]
     fn not_exhausted() {
-        let mut tag = Tag::new(b"foo;\nbar;\n", 0, 0);
+        let mut tag = Tag::new(b"foo;\nbar;\n", Position::new(0, 0));
 
         assert_ok!(tag.next());
 
@@ -393,41 +366,32 @@ mod tests {
     #[test]
     fn into_stored() {
         let buffer = b"foo;";
-        let tag = Tag::new(buffer, 0, 0);
+        let tag = Tag::new(buffer, Position::new(0, 0));
         let stored = tag.into_stored();
         let mut unstored_tag = unsafe { stored.into_tag() };
 
-        assert_ok_eq!(unstored_tag.next(), Values::new(b"foo", 0, 1));
+        assert_ok_eq!(unstored_tag.next(), Values::new(b"foo", Position::new(0, 1)));
         assert_err_eq!(unstored_tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 5)));
     }
 
     #[test]
     fn into_stored_after_iteration() {
         let buffer = b"foo;bar;";
-        let mut tag = Tag::new(buffer, 0, 0);
+        let mut tag = Tag::new(buffer, Position::new(0, 0));
         assert_ok!(tag.next());
         let stored = tag.into_stored();
         let mut unstored_tag = unsafe { stored.into_tag() };
 
-        assert_ok_eq!(unstored_tag.next(), Values::new(b"bar", 0, 5));
+        assert_ok_eq!(unstored_tag.next(), Values::new(b"bar", Position::new(0, 5)));
         assert_err_eq!(unstored_tag.next(), Error::new(error::Kind::EndOfTag, Position::new(0, 9)));
     }
 
     #[test]
-    fn stored_origin_line() {
+    fn stored_origin_position() {
         let buffer = b"foo;bar;";
-        let mut tag = Tag::new(buffer, 1, 2);
+        let mut tag = Tag::new(buffer, Position::new(1, 2));
         assert_ok!(tag.next());
 
-        assert_eq!(tag.into_stored().origin_line(), 1);
-    }
-
-    #[test]
-    fn stored_origin_column() {
-        let buffer = b"foo;bar;";
-        let mut tag = Tag::new(buffer, 1, 2);
-        assert_ok!(tag.next());
-
-        assert_eq!(tag.into_stored().origin_column(), 2);
+        assert_eq!(tag.into_stored().origin_position(), Position::new(1, 2));
     }
 }

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -102,8 +102,7 @@ where
                 Some(byte) => match byte {
                     Ok(byte) => byte,
                     Err(_error) => {
-                        let error =
-                            Error::new(error::Kind::Io, self.current_position);
+                        let error = Error::new(error::Kind::Io, self.current_position);
                         self.encountered_error = Some(error.clone());
                         self.exhausted = true;
                         return Err(error);
@@ -112,17 +111,11 @@ where
                 None => {
                     self.exhausted = true;
                     if self.buffer.is_empty() {
-                        let error = Error::new(
-                            error::Kind::EndOfFile,
-                            self.current_position,
-                        );
+                        let error = Error::new(error::Kind::EndOfFile, self.current_position);
                         self.encountered_error = Some(error.clone());
                         return Err(error);
                     } else {
-                        return Ok(Tag::new(
-                            &self.buffer,
-                            self.started_position,
-                        ));
+                        return Ok(Tag::new(&self.buffer, self.started_position));
                     }
                 }
             };
@@ -250,10 +243,8 @@ where
                                 }
                                 // Non-whitespace bytes are not allowed before the first tag.
                                 if !byte.is_ascii_whitespace() {
-                                    let error = Error::new(
-                                        error::Kind::ExpectedTag,
-                                        self.current_position,
-                                    );
+                                    let error =
+                                        Error::new(error::Kind::ExpectedTag, self.current_position);
                                     self.encountered_error = Some(error.clone());
                                     return Err(error);
                                 }
@@ -293,8 +284,7 @@ where
                     Some(byte) => match byte {
                         Ok(byte) => byte,
                         Err(_error) => {
-                            let error =
-                                Error::new(error::Kind::Io, self.current_position);
+                            let error = Error::new(error::Kind::Io, self.current_position);
                             self.encountered_error = Some(error);
                             self.exhausted = true;
                             break;
@@ -345,10 +335,8 @@ where
                             }
                             // Non-whitespace bytes are not allowed before the first tag.
                             if !byte.is_ascii_whitespace() {
-                                let error = Error::new(
-                                    error::Kind::ExpectedTag,
-                                    self.current_position,
-                                );
+                                let error =
+                                    Error::new(error::Kind::ExpectedTag, self.current_position);
                                 self.encountered_error = Some(error);
                                 break;
                             }
@@ -411,7 +399,10 @@ mod tests {
         let input = b"";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_err_eq!(tags.next(), Error::new(error::Kind::EndOfFile, Position::new(0, 0)));
+        assert_err_eq!(
+            tags.next(),
+            Error::new(error::Kind::EndOfFile, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -419,7 +410,10 @@ mod tests {
         let input = b"foo#bar;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_err_eq!(tags.next(), Error::new(error::Kind::ExpectedTag, Position::new(0, 0)));
+        assert_err_eq!(
+            tags.next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -427,7 +421,10 @@ mod tests {
         let input = b"\n  foo#bar;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_err_eq!(tags.next(), Error::new(error::Kind::ExpectedTag, Position::new(1, 2)));
+        assert_err_eq!(
+            tags.next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -461,7 +458,10 @@ mod tests {
         let input = b"#foo:bar#baz;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_ok_eq!(tags.next(), Tag::new(b"foo:bar#baz;\n", Position::new(0, 0)));
+        assert_ok_eq!(
+            tags.next(),
+            Tag::new(b"foo:bar#baz;\n", Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -478,7 +478,10 @@ mod tests {
         let input = b"#foo:bar;\n\\#baz;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_ok_eq!(tags.next(), Tag::new(b"foo:bar;\n\\#baz;\n", Position::new(0, 0)));
+        assert_ok_eq!(
+            tags.next(),
+            Tag::new(b"foo:bar;\n\\#baz;\n", Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -486,7 +489,10 @@ mod tests {
         let input = b"#foo:bar\n\\#baz;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_ok_eq!(tags.next(), Tag::new(b"foo:bar\n\\#baz;\n", Position::new(0, 0)));
+        assert_ok_eq!(
+            tags.next(),
+            Tag::new(b"foo:bar\n\\#baz;\n", Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -502,7 +508,10 @@ mod tests {
         let input = b"/#foo:bar;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_err_eq!(tags.next(), Error::new(error::Kind::ExpectedTag, Position::new(0, 0)));
+        assert_err_eq!(
+            tags.next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -510,7 +519,10 @@ mod tests {
         let input = b"//#foo:bar;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_err_eq!(tags.next(), Error::new(error::Kind::EndOfFile, Position::new(1, 0)));
+        assert_err_eq!(
+            tags.next(),
+            Error::new(error::Kind::EndOfFile, Position::new(1, 0))
+        );
     }
 
     #[test]
@@ -518,7 +530,10 @@ mod tests {
         let input = b"#foo:bar\\;#baz;\n";
         let mut tags = Tags::new(input.as_slice());
 
-        assert_ok_eq!(tags.next(), Tag::new(b"foo:bar\\;#baz;\n", Position::new(0, 0)));
+        assert_ok_eq!(
+            tags.next(),
+            Tag::new(b"foo:bar\\;#baz;\n", Position::new(0, 0))
+        );
     }
 
     #[test]

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -80,8 +80,8 @@ where
     /// here only lives until the next call to `next()`, because it borrows from a reused internal
     /// buffer.
     pub(in crate::de) fn next(&mut self) -> Result<Tag> {
-        if let Some(error) = self.encountered_error {
-            return Err(error);
+        if let Some(error) = &self.encountered_error {
+            return Err(error.clone());
         }
 
         if let Some(revisit) = self.revisit.take() {
@@ -104,7 +104,7 @@ where
                     Err(_error) => {
                         let error =
                             Error::new(error::Kind::Io, self.current_position);
-                        self.encountered_error = Some(error);
+                        self.encountered_error = Some(error.clone());
                         self.exhausted = true;
                         return Err(error);
                     }
@@ -116,7 +116,7 @@ where
                             error::Kind::EndOfFile,
                             self.current_position,
                         );
-                        self.encountered_error = Some(error);
+                        self.encountered_error = Some(error.clone());
                         return Err(error);
                     } else {
                         return Ok(Tag::new(
@@ -224,7 +224,7 @@ where
                                         error::Kind::ExpectedTag,
                                         self.current_position.decrement_column(),
                                     );
-                                    self.encountered_error = Some(error);
+                                    self.encountered_error = Some(error.clone());
                                     return Err(error);
                                 }
                                 self.tag_state = TagState::InTag;
@@ -245,7 +245,7 @@ where
                                         error::Kind::ExpectedTag,
                                         self.current_position.decrement_column(),
                                     );
-                                    self.encountered_error = Some(error);
+                                    self.encountered_error = Some(error.clone());
                                     return Err(error);
                                 }
                                 // Non-whitespace bytes are not allowed before the first tag.
@@ -254,7 +254,7 @@ where
                                         error::Kind::ExpectedTag,
                                         self.current_position,
                                     );
-                                    self.encountered_error = Some(error);
+                                    self.encountered_error = Some(error.clone());
                                     return Err(error);
                                 }
                             }
@@ -370,8 +370,8 @@ where
             }
         }
 
-        if let Some(err) = self.encountered_error {
-            Err(err)
+        if let Some(error) = &self.encountered_error {
+            Err(error.clone())
         } else {
             Ok(!self.exhausted
                 && matches!(self.tag_state, TagState::InTag | TagState::MaybeEndingTag))

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -222,8 +222,7 @@ where
                                 {
                                     let error = Error::new(
                                         error::Kind::ExpectedTag,
-                                        Position::new(self.current_position.line,
-                                        self.current_position.column - 1),
+                                        self.current_position.decrement_column(),
                                     );
                                     self.encountered_error = Some(error);
                                     return Err(error);
@@ -244,8 +243,7 @@ where
                                 {
                                     let error = Error::new(
                                         error::Kind::ExpectedTag,
-                                        Position::new(self.current_position.line,
-                                        self.current_position.column - 1),
+                                        self.current_position.decrement_column(),
                                     );
                                     self.encountered_error = Some(error);
                                     return Err(error);
@@ -254,8 +252,7 @@ where
                                 if !byte.is_ascii_whitespace() {
                                     let error = Error::new(
                                         error::Kind::ExpectedTag,
-                                        Position::new(self.current_position.line,
-                                        self.current_position.column),
+                                        self.current_position,
                                     );
                                     self.encountered_error = Some(error);
                                     return Err(error);
@@ -273,9 +270,9 @@ where
             }
 
             if matches!(self.newline_state, NewlineState::StartingNewline) {
-                self.current_position = Position::new(self.current_position.line + 1, 0);
+                self.current_position = self.current_position.increment_line();
             } else {
-                self.current_position = Position::new(self.current_position.line, self.current_position.column + 1);
+                self.current_position = self.current_position.increment_column();
             }
 
             if let Some(position) = tag_position {
@@ -321,8 +318,7 @@ where
                             if matches!(self.comment_state, CommentState::MaybeEnteringComment) {
                                 let error = Error::new(
                                     error::Kind::ExpectedTag,
-                                    Position::new(self.current_position.line,
-                                    self.current_position.column - 1),
+                                    self.current_position.decrement_column(),
                                 );
                                 self.encountered_error = Some(error);
                                 break;
@@ -342,8 +338,7 @@ where
                             if matches!(self.comment_state, CommentState::MaybeEnteringComment) {
                                 let error = Error::new(
                                     error::Kind::ExpectedTag,
-                                    Position::new(self.current_position.line,
-                                    self.current_position.column - 1),
+                                    self.current_position.decrement_column(),
                                 );
                                 self.encountered_error = Some(error);
                                 break;
@@ -352,8 +347,7 @@ where
                             if !byte.is_ascii_whitespace() {
                                 let error = Error::new(
                                     error::Kind::ExpectedTag,
-                                    Position::new(self.current_position.line,
-                                    self.current_position.column),
+                                    self.current_position,
                                 );
                                 self.encountered_error = Some(error);
                                 break;
@@ -369,9 +363,9 @@ where
                 }
 
                 if matches!(self.newline_state, NewlineState::StartingNewline) {
-                    self.current_position = Position::new(self.current_position.line + 1, 0);
+                    self.current_position = self.current_position.increment_line();
                 } else {
-                    self.current_position = Position::new(self.current_position.line, self.current_position.column + 1);
+                    self.current_position = self.current_position.increment_column();
                 }
             }
         }

--- a/src/de/parse/value/mod.rs
+++ b/src/de/parse/value/mod.rs
@@ -308,10 +308,7 @@ pub(in crate::de) struct Value<'a> {
 
 impl<'a> Value<'a> {
     pub(in crate::de) fn new(bytes: &'a [u8], position: Position) -> Self {
-        Self {
-            bytes,
-            position,
-        }
+        Self { bytes, position }
     }
 
     pub(in crate::de) fn parse_bool(&self) -> Result<bool> {
@@ -324,26 +321,17 @@ impl<'a> Value<'a> {
                 if parse_ident(value, b"rue") {
                     Ok(true)
                 } else {
-                    Err(Error::new(
-                        error::Kind::ExpectedBool,
-                        self.position,
-                    ))
+                    Err(Error::new(error::Kind::ExpectedBool, self.position))
                 }
             }
             b'f' => {
                 if parse_ident(value, b"alse") {
                     Ok(false)
                 } else {
-                    Err(Error::new(
-                        error::Kind::ExpectedBool,
-                        self.position,
-                    ))
+                    Err(Error::new(error::Kind::ExpectedBool, self.position))
                 }
             }
-            _ => Err(Error::new(
-                error::Kind::ExpectedBool,
-                self.position,
-            )),
+            _ => Err(Error::new(error::Kind::ExpectedBool, self.position)),
         }
     }
 
@@ -420,27 +408,18 @@ impl<'a> Value<'a> {
             if let Some(byte) = value.next() {
                 byte
             } else {
-                return Err(Error::new(
-                    error::Kind::ExpectedChar,
-                    self.position,
-                ));
+                return Err(Error::new(error::Kind::ExpectedChar, self.position));
             }
         };
 
         let width = utf8_char_width(first_byte);
         if width == 0 {
-            Err(Error::new(
-                error::Kind::ExpectedChar,
-                self.position,
-            ))
+            Err(Error::new(error::Kind::ExpectedChar, self.position))
         } else if width == 1 {
             if value.next().is_none() {
                 Ok(first_byte as char)
             } else {
-                Err(Error::new(
-                    error::Kind::ExpectedChar,
-                    self.position,
-                ))
+                Err(Error::new(error::Kind::ExpectedChar, self.position))
             }
         } else {
             let mut buffer = ArrayVec::<_, 4>::new();
@@ -465,10 +444,7 @@ impl<'a> Value<'a> {
                         // the input and the input was nonempty.
                         Ok(unsafe { s.chars().next().unwrap_unchecked() }))?)?
             } else {
-                Err(Error::new(
-                    error::Kind::ExpectedChar,
-                    self.position,
-                ))
+                Err(Error::new(error::Kind::ExpectedChar, self.position))
             }
         }
     }
@@ -487,10 +463,7 @@ impl<'a> Value<'a> {
         if Clean::new(self.bytes).all(|b| b.is_ascii_whitespace()) {
             Ok(())
         } else {
-            Err(Error::new(
-                error::Kind::ExpectedUnit,
-                self.position,
-            ))
+            Err(Error::new(error::Kind::ExpectedUnit, self.position))
         }
     }
 
@@ -555,21 +528,30 @@ mod tests {
     fn parse_i8_positive_overflow() {
         let value = Value::new(b"128", Position::new(0, 0));
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
+        assert_err_eq!(
+            value.parse_i8(),
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 0))
+        );
     }
 
     #[test]
     fn parse_i8_negative_overflow() {
         let value = Value::new(b"-129", Position::new(0, 0));
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
+        assert_err_eq!(
+            value.parse_i8(),
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 0))
+        );
     }
 
     #[test]
     fn parse_i8_invalid() {
         let value = Value::new(b"invalid", Position::new(0, 0));
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
+        assert_err_eq!(
+            value.parse_i8(),
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -776,7 +758,10 @@ mod tests {
 
     #[test]
     fn parse_i128_positive_overflow() {
-        let value = Value::new(b"170141183460469231731687303715884105728", Position::new(0, 0));
+        let value = Value::new(
+            b"170141183460469231731687303715884105728",
+            Position::new(0, 0),
+        );
 
         assert_err_eq!(
             value.parse_i128(),
@@ -786,7 +771,10 @@ mod tests {
 
     #[test]
     fn parse_i128_negative_overflow() {
-        let value = Value::new(b"-170141183460469231731687303715884105729", Position::new(0, 0));
+        let value = Value::new(
+            b"-170141183460469231731687303715884105729",
+            Position::new(0, 0),
+        );
 
         assert_err_eq!(
             value.parse_i128(),
@@ -829,14 +817,20 @@ mod tests {
     fn parse_u8_overflow() {
         let value = Value::new(b"256", Position::new(0, 0));
 
-        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
+        assert_err_eq!(
+            value.parse_u8(),
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 0))
+        );
     }
 
     #[test]
     fn parse_u8_invalid() {
         let value = Value::new(b"invalid", Position::new(0, 0));
 
-        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
+        assert_err_eq!(
+            value.parse_u8(),
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -985,7 +979,10 @@ mod tests {
 
     #[test]
     fn parse_u128_overflow() {
-        let value = Value::new(b"340282366920938463463374607431768211456", Position::new(0, 0));
+        let value = Value::new(
+            b"340282366920938463463374607431768211456",
+            Position::new(0, 0),
+        );
 
         assert_err_eq!(
             value.parse_u128(),

--- a/src/de/parse/value/mod.rs
+++ b/src/de/parse/value/mod.rs
@@ -303,16 +303,14 @@ where
 #[derive(Debug, PartialEq)]
 pub(in crate::de) struct Value<'a> {
     bytes: &'a [u8],
-    line: usize,
-    column: usize,
+    position: Position,
 }
 
 impl<'a> Value<'a> {
-    pub(in crate::de) fn new(bytes: &'a [u8], line: usize, column: usize) -> Self {
+    pub(in crate::de) fn new(bytes: &'a [u8], position: Position) -> Self {
         Self {
             bytes,
-            line,
-            column,
+            position,
         }
     }
 
@@ -320,7 +318,7 @@ impl<'a> Value<'a> {
         let mut value = Trim::new(Clean::new(self.bytes));
         match value
             .next()
-            .ok_or_else(|| Error::new(error::Kind::ExpectedBool, Position::new(self.line, self.column)))?
+            .ok_or_else(|| Error::new(error::Kind::ExpectedBool, self.position))?
         {
             b't' => {
                 if parse_ident(value, b"rue") {
@@ -328,8 +326,7 @@ impl<'a> Value<'a> {
                 } else {
                     Err(Error::new(
                         error::Kind::ExpectedBool,
-                        Position::new(self.line,
-                        self.column),
+                        self.position,
                     ))
                 }
             }
@@ -339,79 +336,77 @@ impl<'a> Value<'a> {
                 } else {
                     Err(Error::new(
                         error::Kind::ExpectedBool,
-                        Position::new(self.line,
-                        self.column),
+                        self.position,
                     ))
                 }
             }
             _ => Err(Error::new(
                 error::Kind::ExpectedBool,
-                Position::new(self.line,
-                self.column),
+                self.position,
             )),
         }
     }
 
     pub(in crate::de) fn parse_i8(&self) -> Result<i8> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI8, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI8, self.position))
     }
 
     pub(in crate::de) fn parse_i16(&self) -> Result<i16> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI16, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI16, self.position))
     }
 
     pub(in crate::de) fn parse_i32(&self) -> Result<i32> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI32, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI32, self.position))
     }
 
     pub(in crate::de) fn parse_i64(&self) -> Result<i64> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI64, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI64, self.position))
     }
 
     #[cfg(has_i128)]
     pub(in crate::de) fn parse_i128(&self) -> Result<i128> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI128, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI128, self.position))
     }
 
     pub(in crate::de) fn parse_u8(&self) -> Result<u8> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU8, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU8, self.position))
     }
 
     pub(in crate::de) fn parse_u16(&self) -> Result<u16> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU16, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU16, self.position))
     }
 
     pub(in crate::de) fn parse_u32(&self) -> Result<u32> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU32, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU32, self.position))
     }
 
     pub(in crate::de) fn parse_u64(&self) -> Result<u64> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU64, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU64, self.position))
     }
 
     #[cfg(has_i128)]
     pub(in crate::de) fn parse_u128(&self) -> Result<u128> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU128, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU128, self.position))
     }
 
     pub(in crate::de) fn parse_f32(&self) -> Result<f32> {
         parse_float(Trim::new(Clean::new(self.bytes)).map(|b| b.to_ascii_lowercase()))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedF32, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedF32, self.position))
     }
 
     pub(in crate::de) fn parse_f64(&self) -> Result<f64> {
         parse_float(Trim::new(Clean::new(self.bytes)).map(|b| b.to_ascii_lowercase()))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedF64, Position::new(self.line, self.column)))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedF64, self.position))
     }
 
     pub(in crate::de) fn parse_char(&self) -> Result<char> {
@@ -427,8 +422,7 @@ impl<'a> Value<'a> {
             } else {
                 return Err(Error::new(
                     error::Kind::ExpectedChar,
-                    Position::new(self.line,
-                    self.column),
+                    self.position,
                 ));
             }
         };
@@ -437,8 +431,7 @@ impl<'a> Value<'a> {
         if width == 0 {
             Err(Error::new(
                 error::Kind::ExpectedChar,
-                Position::new(self.line,
-                self.column),
+                self.position,
             ))
         } else if width == 1 {
             if value.next().is_none() {
@@ -446,8 +439,7 @@ impl<'a> Value<'a> {
             } else {
                 Err(Error::new(
                     error::Kind::ExpectedChar,
-                    Position::new(self.line,
-                    self.column),
+                    self.position,
                 ))
             }
         } else {
@@ -466,7 +458,7 @@ impl<'a> Value<'a> {
             }
             if value.next().is_none() && buffer.len() == width {
                 Ok(str::from_utf8(buffer.as_slice())
-                    .map_err(|_| Error::new(error::Kind::ExpectedChar, Position::new(self.line, self.column)))
+                    .map_err(|_| Error::new(error::Kind::ExpectedChar, self.position))
                     .map(|s|
                         // SAFETY: Since `from_utf8()` returned a string, we can guarantee it has exactly
                         // one value, since the width indicated by the first byte was exactly the length of
@@ -475,8 +467,7 @@ impl<'a> Value<'a> {
             } else {
                 Err(Error::new(
                     error::Kind::ExpectedChar,
-                    Position::new(self.line,
-                    self.column),
+                    self.position,
                 ))
             }
         }
@@ -484,7 +475,7 @@ impl<'a> Value<'a> {
 
     pub(in crate::de) fn parse_string(&self) -> Result<String> {
         String::from_utf8(Clean::new(self.bytes).collect::<Vec<u8>>())
-            .map_err(|_| Error::new(error::Kind::ExpectedString, Position::new(self.line, self.column)))
+            .map_err(|_| Error::new(error::Kind::ExpectedString, self.position))
     }
 
     pub(in crate::de) fn parse_byte_buf(&self) -> Vec<u8> {
@@ -498,15 +489,14 @@ impl<'a> Value<'a> {
         } else {
             Err(Error::new(
                 error::Kind::ExpectedUnit,
-                Position::new(self.line,
-                self.column),
+                self.position,
             ))
         }
     }
 
     pub(in crate::de) fn parse_identifier(&self) -> Result<String> {
         String::from_utf8(Trim::new(Clean::new(self.bytes)).collect::<Vec<u8>>())
-            .map_err(|_| Error::new(error::Kind::ExpectedIdentifier, Position::new(self.line, self.column)))
+            .map_err(|_| Error::new(error::Kind::ExpectedIdentifier, self.position))
     }
 }
 
@@ -518,21 +508,21 @@ mod tests {
 
     #[test]
     fn parse_bool_true() {
-        let value = Value::new(b"true", 0, 0);
+        let value = Value::new(b"true", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_bool(), true);
     }
 
     #[test]
     fn parse_bool_false() {
-        let value = Value::new(b"false", 0, 0);
+        let value = Value::new(b"false", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_bool(), false);
     }
 
     #[test]
     fn parse_bool_invalid() {
-        let value = Value::new(b"not a bool", 0, 0);
+        let value = Value::new(b"not a bool", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_bool(),
@@ -542,77 +532,77 @@ mod tests {
 
     #[test]
     fn parse_i8_positive() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i8(), 42);
     }
 
     #[test]
     fn parse_i8_negative() {
-        let value = Value::new(b"-42", 0, 0);
+        let value = Value::new(b"-42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i8(), -42);
     }
 
     #[test]
     fn parse_i8_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i8(), 0);
     }
 
     #[test]
     fn parse_i8_positive_overflow() {
-        let value = Value::new(b"128", 0, 0);
+        let value = Value::new(b"128", Position::new(0, 0));
 
         assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_i8_negative_overflow() {
-        let value = Value::new(b"-129", 0, 0);
+        let value = Value::new(b"-129", Position::new(0, 0));
 
         assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_i8_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_i8_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i8(), 42);
     }
 
     #[test]
     fn parse_i16_positive() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i16(), 42);
     }
 
     #[test]
     fn parse_i16_negative() {
-        let value = Value::new(b"-42", 0, 0);
+        let value = Value::new(b"-42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i16(), -42);
     }
 
     #[test]
     fn parse_i16_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i16(), 0);
     }
 
     #[test]
     fn parse_i16_positive_overflow() {
-        let value = Value::new(b"32768", 0, 0);
+        let value = Value::new(b"32768", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i16(),
@@ -622,7 +612,7 @@ mod tests {
 
     #[test]
     fn parse_i16_negative_overflow() {
-        let value = Value::new(b"-32769", 0, 0);
+        let value = Value::new(b"-32769", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i16(),
@@ -632,7 +622,7 @@ mod tests {
 
     #[test]
     fn parse_i16_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i16(),
@@ -642,35 +632,35 @@ mod tests {
 
     #[test]
     fn parse_i16_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i16(), 42);
     }
 
     #[test]
     fn parse_i32_positive() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i32(), 42);
     }
 
     #[test]
     fn parse_i32_negative() {
-        let value = Value::new(b"-42", 0, 0);
+        let value = Value::new(b"-42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i32(), -42);
     }
 
     #[test]
     fn parse_i32_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i32(), 0);
     }
 
     #[test]
     fn parse_i32_positive_overflow() {
-        let value = Value::new(b"2147483648", 0, 0);
+        let value = Value::new(b"2147483648", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i32(),
@@ -680,7 +670,7 @@ mod tests {
 
     #[test]
     fn parse_i32_negative_overflow() {
-        let value = Value::new(b"-2147483649", 0, 0);
+        let value = Value::new(b"-2147483649", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i32(),
@@ -690,7 +680,7 @@ mod tests {
 
     #[test]
     fn parse_i32_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i32(),
@@ -700,35 +690,35 @@ mod tests {
 
     #[test]
     fn parse_i32_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i32(), 42);
     }
 
     #[test]
     fn parse_i64_positive() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i64(), 42);
     }
 
     #[test]
     fn parse_i64_negative() {
-        let value = Value::new(b"-42", 0, 0);
+        let value = Value::new(b"-42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i64(), -42);
     }
 
     #[test]
     fn parse_i64_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i64(), 0);
     }
 
     #[test]
     fn parse_i64_positive_overflow() {
-        let value = Value::new(b"9223372036854775808", 0, 0);
+        let value = Value::new(b"9223372036854775808", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i64(),
@@ -738,7 +728,7 @@ mod tests {
 
     #[test]
     fn parse_i64_negative_overflow() {
-        let value = Value::new(b"-9223372036854775809", 0, 0);
+        let value = Value::new(b"-9223372036854775809", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i64(),
@@ -748,7 +738,7 @@ mod tests {
 
     #[test]
     fn parse_i64_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i64(),
@@ -758,35 +748,35 @@ mod tests {
 
     #[test]
     fn parse_i64_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i64(), 42);
     }
 
     #[test]
     fn parse_i128_positive() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i128(), 42);
     }
 
     #[test]
     fn parse_i128_negative() {
-        let value = Value::new(b"-42", 0, 0);
+        let value = Value::new(b"-42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i128(), -42);
     }
 
     #[test]
     fn parse_i128_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i128(), 0);
     }
 
     #[test]
     fn parse_i128_positive_overflow() {
-        let value = Value::new(b"170141183460469231731687303715884105728", 0, 0);
+        let value = Value::new(b"170141183460469231731687303715884105728", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i128(),
@@ -796,7 +786,7 @@ mod tests {
 
     #[test]
     fn parse_i128_negative_overflow() {
-        let value = Value::new(b"-170141183460469231731687303715884105729", 0, 0);
+        let value = Value::new(b"-170141183460469231731687303715884105729", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i128(),
@@ -806,7 +796,7 @@ mod tests {
 
     #[test]
     fn parse_i128_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_i128(),
@@ -816,63 +806,63 @@ mod tests {
 
     #[test]
     fn parse_i128_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_i128(), 42);
     }
 
     #[test]
     fn parse_u8() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u8(), 42);
     }
 
     #[test]
     fn parse_u8_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u8(), 0);
     }
 
     #[test]
     fn parse_u8_overflow() {
-        let value = Value::new(b"256", 0, 0);
+        let value = Value::new(b"256", Position::new(0, 0));
 
         assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_u8_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_u8_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u8(), 42);
     }
 
     #[test]
     fn parse_u16() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u16(), 42);
     }
 
     #[test]
     fn parse_u16_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u16(), 0);
     }
 
     #[test]
     fn parse_u16_overflow() {
-        let value = Value::new(b"65536", 0, 0);
+        let value = Value::new(b"65536", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u16(),
@@ -882,7 +872,7 @@ mod tests {
 
     #[test]
     fn parse_u16_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u16(),
@@ -892,28 +882,28 @@ mod tests {
 
     #[test]
     fn parse_u16_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u16(), 42);
     }
 
     #[test]
     fn parse_u32() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u32(), 42);
     }
 
     #[test]
     fn parse_u32_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u32(), 0);
     }
 
     #[test]
     fn parse_u32_overflow() {
-        let value = Value::new(b"4294967296", 0, 0);
+        let value = Value::new(b"4294967296", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u32(),
@@ -923,7 +913,7 @@ mod tests {
 
     #[test]
     fn parse_u32_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u32(),
@@ -933,28 +923,28 @@ mod tests {
 
     #[test]
     fn parse_u32_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u32(), 42);
     }
 
     #[test]
     fn parse_u64() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u64(), 42);
     }
 
     #[test]
     fn parse_u64_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u64(), 0);
     }
 
     #[test]
     fn parse_u64_overflow() {
-        let value = Value::new(b"18446744073709551616", 0, 0);
+        let value = Value::new(b"18446744073709551616", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u64(),
@@ -964,7 +954,7 @@ mod tests {
 
     #[test]
     fn parse_u64_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u64(),
@@ -974,28 +964,28 @@ mod tests {
 
     #[test]
     fn parse_u64_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u64(), 42);
     }
 
     #[test]
     fn parse_u128() {
-        let value = Value::new(b"42", 0, 0);
+        let value = Value::new(b"42", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u128(), 42);
     }
 
     #[test]
     fn parse_u128_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u128(), 0);
     }
 
     #[test]
     fn parse_u128_overflow() {
-        let value = Value::new(b"340282366920938463463374607431768211456", 0, 0);
+        let value = Value::new(b"340282366920938463463374607431768211456", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u128(),
@@ -1005,7 +995,7 @@ mod tests {
 
     #[test]
     fn parse_u128_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_u128(),
@@ -1015,49 +1005,49 @@ mod tests {
 
     #[test]
     fn parse_u128_whitespace() {
-        let value = Value::new(b"  42 \n", 0, 0);
+        let value = Value::new(b"  42 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_u128(), 42);
     }
 
     #[test]
     fn parse_f32_positive() {
-        let value = Value::new(b"42.9", 0, 0);
+        let value = Value::new(b"42.9", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), 42.9);
     }
 
     #[test]
     fn parse_f32_negative() {
-        let value = Value::new(b"-42.9", 0, 0);
+        let value = Value::new(b"-42.9", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), -42.9);
     }
 
     #[test]
     fn parse_f32_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), 0.0);
     }
 
     #[test]
     fn parse_f32_positive_overflow() {
-        let value = Value::new(b"3.40282347E+39", 0, 0);
+        let value = Value::new(b"3.40282347E+39", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), f32::INFINITY,);
     }
 
     #[test]
     fn parse_f32_negative_overflow() {
-        let value = Value::new(b"-3.40282347E+39", 0, 0);
+        let value = Value::new(b"-3.40282347E+39", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), f32::NEG_INFINITY,);
     }
 
     #[test]
     fn parse_f32_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_f32(),
@@ -1067,7 +1057,7 @@ mod tests {
 
     #[test]
     fn parse_f32_nan() {
-        let value = Value::new(b"NaN", 0, 0);
+        let value = Value::new(b"NaN", Position::new(0, 0));
 
         let result = assert_ok!(value.parse_f32());
         assert!(result.is_nan());
@@ -1075,7 +1065,7 @@ mod tests {
 
     #[test]
     fn parse_f32_negative_nan() {
-        let value = Value::new(b"-NaN", 0, 0);
+        let value = Value::new(b"-NaN", Position::new(0, 0));
 
         let result = assert_ok!(value.parse_f32());
         assert!(result.is_nan());
@@ -1083,63 +1073,63 @@ mod tests {
 
     #[test]
     fn parse_f32_infinity() {
-        let value = Value::new(b"INF", 0, 0);
+        let value = Value::new(b"INF", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), f32::INFINITY);
     }
 
     #[test]
     fn parse_f32_negative_infinity() {
-        let value = Value::new(b"-infinity", 0, 0);
+        let value = Value::new(b"-infinity", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), f32::NEG_INFINITY);
     }
 
     #[test]
     fn parse_f32_whitespace() {
-        let value = Value::new(b"  42.9 \n", 0, 0);
+        let value = Value::new(b"  42.9 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f32(), 42.9);
     }
 
     #[test]
     fn parse_f64_positive() {
-        let value = Value::new(b"42.9", 0, 0);
+        let value = Value::new(b"42.9", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), 42.9);
     }
 
     #[test]
     fn parse_f64_negative() {
-        let value = Value::new(b"-42.9", 0, 0);
+        let value = Value::new(b"-42.9", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), -42.9);
     }
 
     #[test]
     fn parse_f64_zero() {
-        let value = Value::new(b"0", 0, 0);
+        let value = Value::new(b"0", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), 0.0);
     }
 
     #[test]
     fn parse_f64_positive_overflow() {
-        let value = Value::new(b"1.7976931348623157E+309", 0, 0);
+        let value = Value::new(b"1.7976931348623157E+309", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), f64::INFINITY,);
     }
 
     #[test]
     fn parse_f64_negative_overflow() {
-        let value = Value::new(b"-1.7976931348623157E+309", 0, 0);
+        let value = Value::new(b"-1.7976931348623157E+309", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), f64::NEG_INFINITY,);
     }
 
     #[test]
     fn parse_f64_invalid() {
-        let value = Value::new(b"invalid", 0, 0);
+        let value = Value::new(b"invalid", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_f64(),
@@ -1149,14 +1139,14 @@ mod tests {
 
     #[test]
     fn parse_f64_whitespace() {
-        let value = Value::new(b"  42.9 \n", 0, 0);
+        let value = Value::new(b"  42.9 \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), 42.9);
     }
 
     #[test]
     fn parse_f64_nan() {
-        let value = Value::new(b"NaN", 0, 0);
+        let value = Value::new(b"NaN", Position::new(0, 0));
 
         let result = assert_ok!(value.parse_f64());
         assert!(result.is_nan());
@@ -1164,7 +1154,7 @@ mod tests {
 
     #[test]
     fn parse_f64_negative_nan() {
-        let value = Value::new(b"-NaN", 0, 0);
+        let value = Value::new(b"-NaN", Position::new(0, 0));
 
         let result = assert_ok!(value.parse_f64());
         assert!(result.is_nan());
@@ -1172,49 +1162,49 @@ mod tests {
 
     #[test]
     fn parse_f64_infinity() {
-        let value = Value::new(b"INF", 0, 0);
+        let value = Value::new(b"INF", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), f64::INFINITY);
     }
 
     #[test]
     fn parse_f64_negative_infinity() {
-        let value = Value::new(b"-infinity", 0, 0);
+        let value = Value::new(b"-infinity", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_f64(), f64::NEG_INFINITY);
     }
 
     #[test]
     fn parse_char() {
-        let value = Value::new(b"a", 0, 0);
+        let value = Value::new(b"a", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_char(), 'a');
     }
 
     #[test]
     fn parse_char_longer() {
-        let value = Value::new(b"\xF0\x9F\x92\xA3", 0, 0);
+        let value = Value::new(b"\xF0\x9F\x92\xA3", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_char(), '💣');
     }
 
     #[test]
     fn parse_char_surrounded_by_whitespace() {
-        let value = Value::new(b"\n \ta  \t", 0, 0);
+        let value = Value::new(b"\n \ta  \t", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_char(), 'a');
     }
 
     #[test]
     fn parse_char_whitespace() {
-        let value = Value::new(b"\t", 0, 0);
+        let value = Value::new(b"\t", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_char(), '\t');
     }
 
     #[test]
     fn parse_char_multiple_whitespaces() {
-        let value = Value::new(b"\t\n", 0, 0);
+        let value = Value::new(b"\t\n", Position::new(0, 0));
 
         // Can't deduce which whitespace character is meant.
         assert_err_eq!(
@@ -1225,7 +1215,7 @@ mod tests {
 
     #[test]
     fn parse_char_incomplete_char() {
-        let value = Value::new(b"\xF0", 0, 0);
+        let value = Value::new(b"\xF0", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_char(),
@@ -1235,7 +1225,7 @@ mod tests {
 
     #[test]
     fn parse_char_invalid_first_byte() {
-        let value = Value::new(b"\x92", 0, 0);
+        let value = Value::new(b"\x92", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_char(),
@@ -1245,7 +1235,7 @@ mod tests {
 
     #[test]
     fn parse_char_multiple_chars() {
-        let value = Value::new(b"abc", 0, 0);
+        let value = Value::new(b"abc", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_char(),
@@ -1255,28 +1245,28 @@ mod tests {
 
     #[test]
     fn parse_string() {
-        let value = Value::new(b"foo", 0, 0);
+        let value = Value::new(b"foo", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_string(), "foo".to_owned(),);
     }
 
     #[test]
     fn parse_string_escaped() {
-        let value = Value::new(b"\\#foo\\\\bar", 0, 0);
+        let value = Value::new(b"\\#foo\\\\bar", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_string(), "#foo\\bar".to_owned(),);
     }
 
     #[test]
     fn parse_string_comment() {
-        let value = Value::new(b"foo\n// comment\nbar", 0, 0);
+        let value = Value::new(b"foo\n// comment\nbar", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_string(), "foo\n\nbar".to_owned(),);
     }
 
     #[test]
     fn parse_string_fails() {
-        let value = Value::new(b"\xF0\x9Ffoo", 0, 0);
+        let value = Value::new(b"\xF0\x9Ffoo", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_string(),
@@ -1286,42 +1276,42 @@ mod tests {
 
     #[test]
     fn parse_byte_buf() {
-        let value = Value::new(b"foo", 0, 0);
+        let value = Value::new(b"foo", Position::new(0, 0));
 
         assert_eq!(value.parse_byte_buf(), b"foo",);
     }
 
     #[test]
     fn parse_byte_buf_escaped() {
-        let value = Value::new(b"\\#foo\\\\bar", 0, 0);
+        let value = Value::new(b"\\#foo\\\\bar", Position::new(0, 0));
 
         assert_eq!(value.parse_byte_buf(), b"#foo\\bar",);
     }
 
     #[test]
     fn parse_byte_buf_comment() {
-        let value = Value::new(b"foo\n// comment\nbar", 0, 0);
+        let value = Value::new(b"foo\n// comment\nbar", Position::new(0, 0));
 
         assert_eq!(value.parse_byte_buf(), b"foo\n\nbar",);
     }
 
     #[test]
     fn parse_byte_buf_non_ascii() {
-        let value = Value::new(b"\xF0\x9Ffoo", 0, 0);
+        let value = Value::new(b"\xF0\x9Ffoo", Position::new(0, 0));
 
         assert_eq!(value.parse_byte_buf(), b"\xF0\x9Ffoo",);
     }
 
     #[test]
     fn parse_unit() {
-        let value = Value::new(b"", 0, 0);
+        let value = Value::new(b"", Position::new(0, 0));
 
         assert_ok!(value.parse_unit());
     }
 
     #[test]
     fn parse_unit_fails() {
-        let value = Value::new(b"foo", 0, 0);
+        let value = Value::new(b"foo", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_unit(),
@@ -1331,56 +1321,56 @@ mod tests {
 
     #[test]
     fn parse_unit_ignores_whitespace() {
-        let value = Value::new(b"  \n\t ", 0, 0);
+        let value = Value::new(b"  \n\t ", Position::new(0, 0));
 
         assert_ok!(value.parse_unit());
     }
 
     #[test]
     fn parse_unit_ignores_comments() {
-        let value = Value::new(b"//comment\n", 0, 0);
+        let value = Value::new(b"//comment\n", Position::new(0, 0));
 
         assert_ok!(value.parse_unit());
     }
 
     #[test]
     fn parse_identifier() {
-        let value = Value::new(b"foo", 0, 0);
+        let value = Value::new(b"foo", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_identifier(), "foo".to_owned());
     }
 
     #[test]
     fn parse_identifier_escaped() {
-        let value = Value::new(b"foo\\:", 0, 0);
+        let value = Value::new(b"foo\\:", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_identifier(), "foo:".to_owned());
     }
 
     #[test]
     fn parse_identifier_comment() {
-        let value = Value::new(b"foo//comment", 0, 0);
+        let value = Value::new(b"foo//comment", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_identifier(), "foo".to_owned());
     }
 
     #[test]
     fn parse_identifier_trim_whitespace() {
-        let value = Value::new(b" \t foo\n   \n", 0, 0);
+        let value = Value::new(b" \t foo\n   \n", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_identifier(), "foo".to_owned());
     }
 
     #[test]
     fn parse_identifier_whitespace_and_comment() {
-        let value = Value::new(b"foo   //comment", 0, 0);
+        let value = Value::new(b"foo   //comment", Position::new(0, 0));
 
         assert_ok_eq!(value.parse_identifier(), "foo".to_owned());
     }
 
     #[test]
     fn parse_identifier_invalid() {
-        let value = Value::new(b"\xF0\x9Ffoo", 0, 0);
+        let value = Value::new(b"\xF0\x9Ffoo", Position::new(0, 0));
 
         assert_err_eq!(
             value.parse_identifier(),

--- a/src/de/parse/value/mod.rs
+++ b/src/de/parse/value/mod.rs
@@ -2,7 +2,7 @@ mod clean;
 mod trim;
 
 use super::utf8_char_width::utf8_char_width;
-use crate::de::{error, Error, Result};
+use crate::de::{error, Error, Position, Result};
 use arrayvec::ArrayVec;
 use clean::Clean;
 use either::Either;
@@ -320,7 +320,7 @@ impl<'a> Value<'a> {
         let mut value = Trim::new(Clean::new(self.bytes));
         match value
             .next()
-            .ok_or_else(|| Error::new(error::Kind::ExpectedBool, self.line, self.column))?
+            .ok_or_else(|| Error::new(error::Kind::ExpectedBool, Position::new(self.line, self.column)))?
         {
             b't' => {
                 if parse_ident(value, b"rue") {
@@ -328,8 +328,8 @@ impl<'a> Value<'a> {
                 } else {
                     Err(Error::new(
                         error::Kind::ExpectedBool,
-                        self.line,
-                        self.column,
+                        Position::new(self.line,
+                        self.column),
                     ))
                 }
             }
@@ -339,79 +339,79 @@ impl<'a> Value<'a> {
                 } else {
                     Err(Error::new(
                         error::Kind::ExpectedBool,
-                        self.line,
-                        self.column,
+                        Position::new(self.line,
+                        self.column),
                     ))
                 }
             }
             _ => Err(Error::new(
                 error::Kind::ExpectedBool,
-                self.line,
-                self.column,
+                Position::new(self.line,
+                self.column),
             )),
         }
     }
 
     pub(in crate::de) fn parse_i8(&self) -> Result<i8> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI8, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI8, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_i16(&self) -> Result<i16> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI16, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI16, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_i32(&self) -> Result<i32> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI32, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI32, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_i64(&self) -> Result<i64> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI64, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI64, Position::new(self.line, self.column)))
     }
 
     #[cfg(has_i128)]
     pub(in crate::de) fn parse_i128(&self) -> Result<i128> {
         parse_signed_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedI128, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedI128, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_u8(&self) -> Result<u8> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU8, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU8, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_u16(&self) -> Result<u16> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU16, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU16, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_u32(&self) -> Result<u32> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU32, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU32, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_u64(&self) -> Result<u64> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU64, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU64, Position::new(self.line, self.column)))
     }
 
     #[cfg(has_i128)]
     pub(in crate::de) fn parse_u128(&self) -> Result<u128> {
         parse_unsigned_integer(Trim::new(Clean::new(self.bytes)))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedU128, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedU128, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_f32(&self) -> Result<f32> {
         parse_float(Trim::new(Clean::new(self.bytes)).map(|b| b.to_ascii_lowercase()))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedF32, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedF32, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_f64(&self) -> Result<f64> {
         parse_float(Trim::new(Clean::new(self.bytes)).map(|b| b.to_ascii_lowercase()))
-            .ok_or_else(|| Error::new(error::Kind::ExpectedF64, self.line, self.column))
+            .ok_or_else(|| Error::new(error::Kind::ExpectedF64, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_char(&self) -> Result<char> {
@@ -427,8 +427,8 @@ impl<'a> Value<'a> {
             } else {
                 return Err(Error::new(
                     error::Kind::ExpectedChar,
-                    self.line,
-                    self.column,
+                    Position::new(self.line,
+                    self.column),
                 ));
             }
         };
@@ -437,8 +437,8 @@ impl<'a> Value<'a> {
         if width == 0 {
             Err(Error::new(
                 error::Kind::ExpectedChar,
-                self.line,
-                self.column,
+                Position::new(self.line,
+                self.column),
             ))
         } else if width == 1 {
             if value.next().is_none() {
@@ -446,8 +446,8 @@ impl<'a> Value<'a> {
             } else {
                 Err(Error::new(
                     error::Kind::ExpectedChar,
-                    self.line,
-                    self.column,
+                    Position::new(self.line,
+                    self.column),
                 ))
             }
         } else {
@@ -466,7 +466,7 @@ impl<'a> Value<'a> {
             }
             if value.next().is_none() && buffer.len() == width {
                 Ok(str::from_utf8(buffer.as_slice())
-                    .map_err(|_| Error::new(error::Kind::ExpectedChar, self.line, self.column))
+                    .map_err(|_| Error::new(error::Kind::ExpectedChar, Position::new(self.line, self.column)))
                     .map(|s|
                         // SAFETY: Since `from_utf8()` returned a string, we can guarantee it has exactly
                         // one value, since the width indicated by the first byte was exactly the length of
@@ -475,8 +475,8 @@ impl<'a> Value<'a> {
             } else {
                 Err(Error::new(
                     error::Kind::ExpectedChar,
-                    self.line,
-                    self.column,
+                    Position::new(self.line,
+                    self.column),
                 ))
             }
         }
@@ -484,7 +484,7 @@ impl<'a> Value<'a> {
 
     pub(in crate::de) fn parse_string(&self) -> Result<String> {
         String::from_utf8(Clean::new(self.bytes).collect::<Vec<u8>>())
-            .map_err(|_| Error::new(error::Kind::ExpectedString, self.line, self.column))
+            .map_err(|_| Error::new(error::Kind::ExpectedString, Position::new(self.line, self.column)))
     }
 
     pub(in crate::de) fn parse_byte_buf(&self) -> Vec<u8> {
@@ -498,22 +498,22 @@ impl<'a> Value<'a> {
         } else {
             Err(Error::new(
                 error::Kind::ExpectedUnit,
-                self.line,
-                self.column,
+                Position::new(self.line,
+                self.column),
             ))
         }
     }
 
     pub(in crate::de) fn parse_identifier(&self) -> Result<String> {
         String::from_utf8(Trim::new(Clean::new(self.bytes)).collect::<Vec<u8>>())
-            .map_err(|_| Error::new(error::Kind::ExpectedIdentifier, self.line, self.column))
+            .map_err(|_| Error::new(error::Kind::ExpectedIdentifier, Position::new(self.line, self.column)))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Value;
-    use crate::de::{error, Error};
+    use crate::de::{error, Error, Position};
     use claim::{assert_err_eq, assert_ok, assert_ok_eq};
 
     #[test]
@@ -536,7 +536,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_bool(),
-            Error::new(error::Kind::ExpectedBool, 0, 0)
+            Error::new(error::Kind::ExpectedBool, Position::new(0, 0))
         );
     }
 
@@ -565,21 +565,21 @@ mod tests {
     fn parse_i8_positive_overflow() {
         let value = Value::new(b"128", 0, 0);
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, 0, 0));
+        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_i8_negative_overflow() {
         let value = Value::new(b"-129", 0, 0);
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, 0, 0));
+        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_i8_invalid() {
         let value = Value::new(b"invalid", 0, 0);
 
-        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, 0, 0));
+        assert_err_eq!(value.parse_i8(), Error::new(error::Kind::ExpectedI8, Position::new(0, 0)));
     }
 
     #[test]
@@ -616,7 +616,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i16(),
-            Error::new(error::Kind::ExpectedI16, 0, 0)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 0))
         );
     }
 
@@ -626,7 +626,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i16(),
-            Error::new(error::Kind::ExpectedI16, 0, 0)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 0))
         );
     }
 
@@ -636,7 +636,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i16(),
-            Error::new(error::Kind::ExpectedI16, 0, 0)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 0))
         );
     }
 
@@ -674,7 +674,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i32(),
-            Error::new(error::Kind::ExpectedI32, 0, 0)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 0))
         );
     }
 
@@ -684,7 +684,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i32(),
-            Error::new(error::Kind::ExpectedI32, 0, 0)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 0))
         );
     }
 
@@ -694,7 +694,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i32(),
-            Error::new(error::Kind::ExpectedI32, 0, 0)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 0))
         );
     }
 
@@ -732,7 +732,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i64(),
-            Error::new(error::Kind::ExpectedI64, 0, 0)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 0))
         );
     }
 
@@ -742,7 +742,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i64(),
-            Error::new(error::Kind::ExpectedI64, 0, 0)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 0))
         );
     }
 
@@ -752,7 +752,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i64(),
-            Error::new(error::Kind::ExpectedI64, 0, 0)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 0))
         );
     }
 
@@ -790,7 +790,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i128(),
-            Error::new(error::Kind::ExpectedI128, 0, 0)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 0))
         );
     }
 
@@ -800,7 +800,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i128(),
-            Error::new(error::Kind::ExpectedI128, 0, 0)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 0))
         );
     }
 
@@ -810,7 +810,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_i128(),
-            Error::new(error::Kind::ExpectedI128, 0, 0)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 0))
         );
     }
 
@@ -839,14 +839,14 @@ mod tests {
     fn parse_u8_overflow() {
         let value = Value::new(b"256", 0, 0);
 
-        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, 0, 0));
+        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
     }
 
     #[test]
     fn parse_u8_invalid() {
         let value = Value::new(b"invalid", 0, 0);
 
-        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, 0, 0));
+        assert_err_eq!(value.parse_u8(), Error::new(error::Kind::ExpectedU8, Position::new(0, 0)));
     }
 
     #[test]
@@ -876,7 +876,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u16(),
-            Error::new(error::Kind::ExpectedU16, 0, 0)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 0))
         );
     }
 
@@ -886,7 +886,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u16(),
-            Error::new(error::Kind::ExpectedU16, 0, 0)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 0))
         );
     }
 
@@ -917,7 +917,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u32(),
-            Error::new(error::Kind::ExpectedU32, 0, 0)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 0))
         );
     }
 
@@ -927,7 +927,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u32(),
-            Error::new(error::Kind::ExpectedU32, 0, 0)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 0))
         );
     }
 
@@ -958,7 +958,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u64(),
-            Error::new(error::Kind::ExpectedU64, 0, 0)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 0))
         );
     }
 
@@ -968,7 +968,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u64(),
-            Error::new(error::Kind::ExpectedU64, 0, 0)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 0))
         );
     }
 
@@ -999,7 +999,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u128(),
-            Error::new(error::Kind::ExpectedU128, 0, 0)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 0))
         );
     }
 
@@ -1009,7 +1009,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_u128(),
-            Error::new(error::Kind::ExpectedU128, 0, 0)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 0))
         );
     }
 
@@ -1061,7 +1061,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_f32(),
-            Error::new(error::Kind::ExpectedF32, 0, 0)
+            Error::new(error::Kind::ExpectedF32, Position::new(0, 0))
         );
     }
 
@@ -1143,7 +1143,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_f64(),
-            Error::new(error::Kind::ExpectedF64, 0, 0)
+            Error::new(error::Kind::ExpectedF64, Position::new(0, 0))
         );
     }
 
@@ -1219,7 +1219,7 @@ mod tests {
         // Can't deduce which whitespace character is meant.
         assert_err_eq!(
             value.parse_char(),
-            Error::new(error::Kind::ExpectedChar, 0, 0)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 0))
         );
     }
 
@@ -1229,7 +1229,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_char(),
-            Error::new(error::Kind::ExpectedChar, 0, 0)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 0))
         );
     }
 
@@ -1239,7 +1239,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_char(),
-            Error::new(error::Kind::ExpectedChar, 0, 0)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 0))
         );
     }
 
@@ -1249,7 +1249,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_char(),
-            Error::new(error::Kind::ExpectedChar, 0, 0)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 0))
         );
     }
 
@@ -1280,7 +1280,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_string(),
-            Error::new(error::Kind::ExpectedString, 0, 0),
+            Error::new(error::Kind::ExpectedString, Position::new(0, 0)),
         );
     }
 
@@ -1325,7 +1325,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_unit(),
-            Error::new(error::Kind::ExpectedUnit, 0, 0)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 0))
         );
     }
 
@@ -1384,7 +1384,7 @@ mod tests {
 
         assert_err_eq!(
             value.parse_identifier(),
-            Error::new(error::Kind::ExpectedIdentifier, 0, 0)
+            Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 0))
         );
     }
 }

--- a/src/de/parse/value/mod.rs
+++ b/src/de/parse/value/mod.rs
@@ -311,6 +311,10 @@ impl<'a> Value<'a> {
         Self { bytes, position }
     }
 
+    pub(in crate::de) fn position(&self) -> Position {
+        self.position
+    }
+
     pub(in crate::de) fn parse_bool(&self) -> Result<bool> {
         let mut value = Trim::new(Clean::new(self.bytes));
         match value
@@ -478,6 +482,13 @@ mod tests {
     use super::Value;
     use crate::de::{error, Error, Position};
     use claim::{assert_err_eq, assert_ok, assert_ok_eq};
+
+    #[test]
+    fn get_position() {
+        let value = Value::new(b"", Position::new(1, 2));
+
+        assert_eq!(value.position(), Position::new(1, 2));
+    }
 
     #[test]
     fn parse_bool_true() {

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -1,5 +1,5 @@
 use super::Value;
-use crate::de::{error, Error, Result};
+use crate::de::{error, Error, Position, Result};
 use std::slice;
 
 #[derive(Debug, PartialEq)]
@@ -164,8 +164,8 @@ impl<'a> Values<'a> {
             } else {
                 return Err(Error::new(
                     error::Kind::EndOfValues,
-                    self.current_line,
-                    self.current_column,
+                    Position::new(self.current_line,
+                    self.current_column),
                 ));
             }
         }
@@ -177,8 +177,8 @@ impl<'a> Values<'a> {
         } else {
             Err(Error::new(
                 error::Kind::UnexpectedValue,
-                self.current_line,
-                self.current_column,
+                Position::new(self.current_line,
+                self.current_column),
             ))
         }
     }
@@ -200,7 +200,7 @@ impl<'a> Values<'a> {
 #[cfg(test)]
 mod tests {
     use super::Values;
-    use crate::de::{error, parse::Value, Error};
+    use crate::de::{error, parse::Value, Error, Position};
     use claim::{assert_err_eq, assert_ok, assert_ok_eq};
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
         let mut values = Values::new(b"", 0, 0);
 
         assert_ok_eq!(values.next(), Value::new(b"", 0, 0));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 0, 0));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 0)));
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod tests {
         let mut values = Values::new(b"foo", 0, 0);
 
         assert_ok_eq!(values.next(), Value::new(b"foo", 0, 0));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 0, 3));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 3)));
     }
 
     #[test]
@@ -226,7 +226,7 @@ mod tests {
         assert_ok_eq!(values.next(), Value::new(b"foo", 0, 0));
         assert_ok_eq!(values.next(), Value::new(b"bar", 0, 4));
         assert_ok_eq!(values.next(), Value::new(b"baz", 0, 8));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 0, 11));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 11)));
     }
 
     #[test]
@@ -235,7 +235,7 @@ mod tests {
 
         assert_ok_eq!(values.next(), Value::new(b"foo//comment:\n", 0, 0));
         assert_ok_eq!(values.next(), Value::new(b"bar", 1, 1));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 1, 4));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(1, 4)));
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
         assert_ok_eq!(values.next(), Value::new(b"foo\\/\\/comment", 0, 0));
         assert_ok_eq!(values.next(), Value::new(b"\n", 0, 15));
         assert_ok_eq!(values.next(), Value::new(b"bar", 1, 1));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 1, 4));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(1, 4)));
     }
 
     #[test]
@@ -253,7 +253,7 @@ mod tests {
         let mut values = Values::new(b"foo\\:bar", 0, 0);
 
         assert_ok_eq!(values.next(), Value::new(b"foo\\:bar", 0, 0));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 0, 8));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 8)));
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
 
         assert_ok_eq!(values.next(), Value::new(b"foo\\\\", 0, 0));
         assert_ok_eq!(values.next(), Value::new(b"bar", 0, 6));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, 0, 9));
+        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 9)));
     }
 
     #[test]
@@ -282,7 +282,7 @@ mod tests {
 
         assert_err_eq!(
             values.assert_exhausted(),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -296,7 +296,7 @@ mod tests {
         assert_ok_eq!(unstored_values.next(), Value::new(b"foo", 0, 0));
         assert_err_eq!(
             unstored_values.next(),
-            Error::new(error::Kind::EndOfValues, 0, 3)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 3))
         );
     }
 
@@ -311,7 +311,7 @@ mod tests {
         assert_ok_eq!(unstored_values.next(), Value::new(b"bar", 0, 4));
         assert_err_eq!(
             unstored_values.next(),
-            Error::new(error::Kind::EndOfValues, 0, 7)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 7))
         );
     }
 }

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -130,9 +130,9 @@ impl<'a> Values<'a> {
                 }
 
                 if matches!(byte, b'\n') {
-                    self.current_position = Position::new(self.current_position.line + 1, 0);
+                    self.current_position = self.current_position.increment_line();
                 } else {
-                    self.current_position = Position::new(self.current_position.line, self.current_position.column + 1);
+                    self.current_position = self.current_position.increment_column();
                 }
                 self.current_byte_index += 1;
 

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -151,10 +151,7 @@ impl<'a> Values<'a> {
                     self.started_position,
                 ));
             } else {
-                return Err(Error::new(
-                    error::Kind::EndOfValues,
-                    self.current_position,
-                ));
+                return Err(Error::new(error::Kind::EndOfValues, self.current_position));
             }
         }
     }
@@ -194,7 +191,10 @@ mod tests {
         let mut values = Values::new(b"", Position::new(0, 0));
 
         assert_ok_eq!(values.next(), Value::new(b"", Position::new(0, 0)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 0)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -202,7 +202,10 @@ mod tests {
         let mut values = Values::new(b"foo", Position::new(0, 0));
 
         assert_ok_eq!(values.next(), Value::new(b"foo", Position::new(0, 0)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 3)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 3))
+        );
     }
 
     #[test]
@@ -212,26 +215,41 @@ mod tests {
         assert_ok_eq!(values.next(), Value::new(b"foo", Position::new(0, 0)));
         assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(0, 4)));
         assert_ok_eq!(values.next(), Value::new(b"baz", Position::new(0, 8)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 11)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 11))
+        );
     }
 
     #[test]
     fn comment() {
         let mut values = Values::new(b"foo//comment:\n:bar", Position::new(0, 0));
 
-        assert_ok_eq!(values.next(), Value::new(b"foo//comment:\n", Position::new(0, 0)));
+        assert_ok_eq!(
+            values.next(),
+            Value::new(b"foo//comment:\n", Position::new(0, 0))
+        );
         assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(1, 1)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(1, 4)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(1, 4))
+        );
     }
 
     #[test]
     fn escaped_comment() {
         let mut values = Values::new(b"foo\\/\\/comment:\n:bar", Position::new(0, 0));
 
-        assert_ok_eq!(values.next(), Value::new(b"foo\\/\\/comment", Position::new(0, 0)));
+        assert_ok_eq!(
+            values.next(),
+            Value::new(b"foo\\/\\/comment", Position::new(0, 0))
+        );
         assert_ok_eq!(values.next(), Value::new(b"\n", Position::new(0, 15)));
         assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(1, 1)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(1, 4)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(1, 4))
+        );
     }
 
     #[test]
@@ -239,7 +257,10 @@ mod tests {
         let mut values = Values::new(b"foo\\:bar", Position::new(0, 0));
 
         assert_ok_eq!(values.next(), Value::new(b"foo\\:bar", Position::new(0, 0)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 8)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 8))
+        );
     }
 
     #[test]
@@ -248,7 +269,10 @@ mod tests {
 
         assert_ok_eq!(values.next(), Value::new(b"foo\\\\", Position::new(0, 0)));
         assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(0, 6)));
-        assert_err_eq!(values.next(), Error::new(error::Kind::EndOfValues, Position::new(0, 9)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 9))
+        );
     }
 
     #[test]
@@ -279,7 +303,10 @@ mod tests {
         let stored = values.into_stored();
         let mut unstored_values = unsafe { stored.into_values() };
 
-        assert_ok_eq!(unstored_values.next(), Value::new(b"foo", Position::new(0, 0)));
+        assert_ok_eq!(
+            unstored_values.next(),
+            Value::new(b"foo", Position::new(0, 0))
+        );
         assert_err_eq!(
             unstored_values.next(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 3))
@@ -294,7 +321,10 @@ mod tests {
         let stored = values.into_stored();
         let mut unstored_values = unsafe { stored.into_values() };
 
-        assert_ok_eq!(unstored_values.next(), Value::new(b"bar", Position::new(0, 4)));
+        assert_ok_eq!(
+            unstored_values.next(),
+            Value::new(b"bar", Position::new(0, 4))
+        );
         assert_err_eq!(
             unstored_values.next(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 7))

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -1,4 +1,14 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::de) struct Position {
-    line: usize,
-    column: usize,
+    pub(in crate::de) line: usize,
+    pub(in crate::de) column: usize,
+}
+
+impl Position {
+    pub(in crate::de) fn new(line: usize, column: usize) -> Self {
+        Self {
+            line,
+            column,
+        }
+    }
 }

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(in crate::de) struct Position {
-    pub(in crate::de) line: usize,
-    pub(in crate::de) column: usize,
+    line: usize,
+    column: usize,
 }
 
 impl Position {
@@ -10,5 +10,52 @@ impl Position {
             line,
             column,
         }
+    }
+
+    pub(in crate::de) fn increment_line(self) -> Self {
+        Self {
+            line: self.line + 1,
+            column: 0,
+        }
+    }
+
+    pub(in crate::de) fn increment_column(self) -> Self {
+        Self {
+            line: self.line,
+            column: self.column + 1,
+        }
+    }
+
+    pub(in crate::de) fn decrement_column(self) -> Self {
+        Self {
+            line: self.line,
+            column: self.column - 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Position;
+
+    #[test]
+    fn increment_line() {
+        let position = Position::new(5, 7);
+
+        assert_eq!(position.increment_line(), Position::new(6, 0));
+    }
+
+    #[test]
+    fn increment_column() {
+        let position = Position::new(5, 7);
+
+        assert_eq!(position.increment_column(), Position::new(5, 8));
+    }
+
+    #[test]
+    fn decrement_column() {
+        let position = Position::new(5, 7);
+
+        assert_eq!(position.decrement_column(), Position::new(5, 6));
     }
 }

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -1,0 +1,4 @@
+pub(in crate::de) struct Position {
+    line: usize,
+    column: usize,
+}

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -9,6 +9,14 @@ impl Position {
         Self { line, column }
     }
 
+    pub(in crate::de) fn line(&self) -> usize {
+        self.line
+    }
+
+    pub(in crate::de) fn column(&self) -> usize {
+        self.column
+    }
+
     pub(in crate::de) fn increment_line(self) -> Self {
         Self {
             line: self.line + 1,
@@ -34,6 +42,20 @@ impl Position {
 #[cfg(test)]
 mod tests {
     use super::Position;
+
+    #[test]
+    fn line() {
+        let position = Position::new(5, 7);
+
+        assert_eq!(position.line(), 5);
+    }
+
+    #[test]
+    fn column() {
+        let position = Position::new(5, 7);
+
+        assert_eq!(position.column(), 7);
+    }
 
     #[test]
     fn increment_line() {

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -6,10 +6,7 @@ pub(in crate::de) struct Position {
 
 impl Position {
     pub(in crate::de) fn new(line: usize, column: usize) -> Self {
-        Self {
-            line,
-            column,
-        }
+        Self { line, column }
     }
 
     pub(in crate::de) fn increment_line(self) -> Self {

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -32,10 +32,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_bool()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_bool(parsed)
+        visitor.visit_bool(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
@@ -45,10 +49,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i8()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_i8(parsed)
+        visitor.visit_i8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
@@ -58,10 +66,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i16()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_i16(parsed)
+        visitor.visit_i16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
@@ -71,10 +83,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i32()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_i32(parsed)
+        visitor.visit_i32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
@@ -84,10 +100,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i64()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_i64(parsed)
+        visitor.visit_i64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -98,10 +118,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i128()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_i128(parsed)
+        visitor.visit_i128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -111,10 +135,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u8()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_u8(parsed)
+        visitor.visit_u8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
@@ -124,10 +152,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u16()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_u16(parsed)
+        visitor.visit_u16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
@@ -137,10 +169,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u32()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_u32(parsed)
+        visitor.visit_u32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
@@ -150,10 +186,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u64()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_u64(parsed)
+        visitor.visit_u64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -164,10 +204,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u128()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_u128(parsed)
+        visitor.visit_u128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -177,10 +221,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_f32()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_f32(parsed)
+        visitor.visit_f32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
@@ -190,10 +238,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_f64()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_f64(parsed)
+        visitor.visit_f64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
@@ -203,10 +255,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_char()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_char(parsed)
+        visitor.visit_char(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -216,11 +272,15 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         // Parsed string must be owned, since it removes escaping and comments.
         let parsed = value.parse_string()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
@@ -230,10 +290,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_string()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_string(parsed)
+        visitor.visit_string(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
@@ -243,11 +307,15 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         // Parsed bytes must be owned, since it removes escaping and comments.
         let parsed = value.parse_byte_buf();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_bytes(&parsed)
+        visitor.visit_bytes(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -257,10 +325,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_byte_buf();
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_byte_buf(parsed)
+        visitor.visit_byte_buf(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
@@ -277,10 +349,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         value.parse_unit()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -290,10 +366,14 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         value.parse_unit()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -391,11 +471,15 @@ where
         let mut tag = self.tags.next()?;
         let mut values = tag.next()?;
         let value = values.next()?;
+        let value_position = value.position();
         // Parsed string must be owned, since it removes escaping and comments.
         let parsed = value.parse_identifier()?;
         values.assert_exhausted()?;
         tag.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -444,6 +528,46 @@ mod tests {
     }
 
     #[test]
+    fn bool_custom_error() {
+        #[derive(Debug)]
+        struct CustomBool;
+
+        impl<'de> Deserialize<'de> for CustomBool {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomBoolVisitor;
+
+                impl<'de> Visitor<'de> for CustomBoolVisitor {
+                    type Value = CustomBool;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_bool(CustomBoolVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#true;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomBool::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn i8() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -481,6 +605,46 @@ mod tests {
         assert_err_eq!(
             i8::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
+        );
+    }
+
+    #[test]
+    fn i8_custom_error() {
+        #[derive(Debug)]
+        struct CustomI8;
+
+        impl<'de> Deserialize<'de> for CustomI8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI8Visitor;
+
+                impl<'de> Visitor<'de> for CustomI8Visitor {
+                    type Value = CustomI8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i8<E>(self, _value: i8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i8(CustomI8Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomI8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -526,6 +690,46 @@ mod tests {
     }
 
     #[test]
+    fn i16_custom_error() {
+        #[derive(Debug)]
+        struct CustomI16;
+
+        impl<'de> Deserialize<'de> for CustomI16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI16Visitor;
+
+                impl<'de> Visitor<'de> for CustomI16Visitor {
+                    type Value = CustomI16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i16<E>(self, _value: i16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i16(CustomI16Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomI16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn i32() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -567,6 +771,46 @@ mod tests {
     }
 
     #[test]
+    fn i32_custom_error() {
+        #[derive(Debug)]
+        struct CustomI32;
+
+        impl<'de> Deserialize<'de> for CustomI32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI32Visitor;
+
+                impl<'de> Visitor<'de> for CustomI32Visitor {
+                    type Value = CustomI32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i32<E>(self, _value: i32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i32(CustomI32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomI32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn i64() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -604,6 +848,46 @@ mod tests {
         assert_err_eq!(
             i64::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
+        );
+    }
+
+    #[test]
+    fn i64_custom_error() {
+        #[derive(Debug)]
+        struct CustomI64;
+
+        impl<'de> Deserialize<'de> for CustomI64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI64Visitor;
+
+                impl<'de> Visitor<'de> for CustomI64Visitor {
+                    type Value = CustomI64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i64(CustomI64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomI64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -653,6 +937,46 @@ mod tests {
     }
 
     #[test]
+    fn i128_custom_error() {
+        #[derive(Debug)]
+        struct CustomI128;
+
+        impl<'de> Deserialize<'de> for CustomI128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI128Visitor;
+
+                impl<'de> Visitor<'de> for CustomI128Visitor {
+                    type Value = CustomI128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i128<E>(self, _value: i128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i128(CustomI128Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomI128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u8() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -690,6 +1014,46 @@ mod tests {
         assert_err_eq!(
             u8::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
+        );
+    }
+
+    #[test]
+    fn u8_custom_error() {
+        #[derive(Debug)]
+        struct CustomU8;
+
+        impl<'de> Deserialize<'de> for CustomU8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU8Visitor;
+
+                impl<'de> Visitor<'de> for CustomU8Visitor {
+                    type Value = CustomU8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u8<E>(self, _value: u8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u8(CustomU8Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomU8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -735,6 +1099,46 @@ mod tests {
     }
 
     #[test]
+    fn u16_custom_error() {
+        #[derive(Debug)]
+        struct CustomU16;
+
+        impl<'de> Deserialize<'de> for CustomU16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU16Visitor;
+
+                impl<'de> Visitor<'de> for CustomU16Visitor {
+                    type Value = CustomU16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u16<E>(self, _value: u16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u16(CustomU16Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomU16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u32() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -776,6 +1180,46 @@ mod tests {
     }
 
     #[test]
+    fn u32_custom_error() {
+        #[derive(Debug)]
+        struct CustomU32;
+
+        impl<'de> Deserialize<'de> for CustomU32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU32Visitor;
+
+                impl<'de> Visitor<'de> for CustomU32Visitor {
+                    type Value = CustomU32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u32<E>(self, _value: u32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u32(CustomU32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomU32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn u64() {
         let mut tags = Tags::new(b"#42;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -813,6 +1257,46 @@ mod tests {
         assert_err_eq!(
             u64::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
+        );
+    }
+
+    #[test]
+    fn u64_custom_error() {
+        #[derive(Debug)]
+        struct CustomU64;
+
+        impl<'de> Deserialize<'de> for CustomU64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU64Visitor;
+
+                impl<'de> Visitor<'de> for CustomU64Visitor {
+                    type Value = CustomU64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u64(CustomU64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomU64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -862,6 +1346,46 @@ mod tests {
     }
 
     #[test]
+    fn u128_custom_error() {
+        #[derive(Debug)]
+        struct CustomU128;
+
+        impl<'de> Deserialize<'de> for CustomU128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU128Visitor;
+
+                impl<'de> Visitor<'de> for CustomU128Visitor {
+                    type Value = CustomU128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u128<E>(self, _value: u128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u128(CustomU128Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomU128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn f32() {
         let mut tags = Tags::new(b"#42.9;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -899,6 +1423,46 @@ mod tests {
         assert_err_eq!(
             f32::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
+        );
+    }
+
+    #[test]
+    fn f32_custom_error() {
+        #[derive(Debug)]
+        struct CustomF32;
+
+        impl<'de> Deserialize<'de> for CustomF32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF32Visitor;
+
+                impl<'de> Visitor<'de> for CustomF32Visitor {
+                    type Value = CustomF32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f32<E>(self, _value: f32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f32(CustomF32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42.9;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomF32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -944,6 +1508,46 @@ mod tests {
     }
 
     #[test]
+    fn f64_custom_error() {
+        #[derive(Debug)]
+        struct CustomF64;
+
+        impl<'de> Deserialize<'de> for CustomF64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF64Visitor;
+
+                impl<'de> Visitor<'de> for CustomF64Visitor {
+                    type Value = CustomF64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f64(CustomF64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#42.9;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomF64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn char() {
         let mut tags = Tags::new(b"#a;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -981,6 +1585,46 @@ mod tests {
         assert_err_eq!(
             char::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 3))
+        );
+    }
+
+    #[test]
+    fn char_custom_error() {
+        #[derive(Debug)]
+        struct CustomChar;
+
+        impl<'de> Deserialize<'de> for CustomChar {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomCharVisitor;
+
+                impl<'de> Visitor<'de> for CustomCharVisitor {
+                    type Value = CustomChar;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_char<E>(self, _value: char) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_char(CustomCharVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#a;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomChar::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1026,6 +1670,46 @@ mod tests {
     }
 
     #[test]
+    fn string_custom_error() {
+        #[derive(Debug)]
+        struct CustomString;
+
+        impl<'de> Deserialize<'de> for CustomString {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomStringVisitor;
+
+                impl<'de> Visitor<'de> for CustomStringVisitor {
+                    type Value = CustomString;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_string(CustomStringVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomString::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
     fn byte_buf() {
         let mut tags = Tags::new(b"#foo;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
@@ -1052,6 +1736,46 @@ mod tests {
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
+        );
+    }
+
+    #[test]
+    fn byte_buf_custom_error() {
+        #[derive(Debug)]
+        struct CustomByteBuf;
+
+        impl<'de> Deserialize<'de> for CustomByteBuf {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomByteBufVisitor;
+
+                impl<'de> Visitor<'de> for CustomByteBufVisitor {
+                    type Value = CustomByteBuf;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_byte_buf<E>(self, _value: Vec<u8>) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_byte_buf(CustomByteBufVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomByteBuf::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1093,6 +1817,46 @@ mod tests {
         assert_err_eq!(
             <()>::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 2))
+        );
+    }
+
+    #[test]
+    fn unit_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnit;
+
+        impl<'de> Deserialize<'de> for CustomUnit {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitVisitor {
+                    type Value = CustomUnit;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit(CustomUnitVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomUnit::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1142,6 +1906,46 @@ mod tests {
         assert_err_eq!(
             Unit::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 2))
+        );
+    }
+
+    #[test]
+    fn unit_struct_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnitStruct;
+
+        impl<'de> Deserialize<'de> for CustomUnitStruct {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitStructVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitStructVisitor {
+                    type Value = CustomUnitStruct;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit_struct("CustomUnitStruct", CustomUnitStructVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomUnitStruct::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 
@@ -1473,6 +2277,46 @@ mod tests {
         assert_err_eq!(
             Identifier::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
+        );
+    }
+
+    #[test]
+    fn identifier_custom_error() {
+        #[derive(Debug)]
+        struct CustomIdentifier;
+
+        impl<'de> Deserialize<'de> for CustomIdentifier {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomIdentifierVisitor;
+
+                impl<'de> Visitor<'de> for CustomIdentifierVisitor {
+                    type Value = CustomIdentifier;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_identifier(CustomIdentifierVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            CustomIdentifier::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
     }
 }

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -409,7 +409,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Deserializer;
-    use crate::de::{error, parse::Tags, Error};
+    use crate::de::{error, parse::Tags, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use serde_bytes::ByteBuf;
@@ -439,7 +439,7 @@ mod tests {
 
         assert_err_eq!(
             bool::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedBool, 0, 1)
+            Error::new(error::Kind::ExpectedBool, Position::new(0, 1))
         );
     }
 
@@ -458,7 +458,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 1)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 1))
         );
     }
 
@@ -469,7 +469,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -480,7 +480,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -499,7 +499,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 1)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 1))
         );
     }
 
@@ -510,7 +510,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -521,7 +521,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -540,7 +540,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI32, 0, 1)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 1))
         );
     }
 
@@ -551,7 +551,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -562,7 +562,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -581,7 +581,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 1)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 1))
         );
     }
 
@@ -592,7 +592,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -603,7 +603,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -624,7 +624,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 1)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 1))
         );
     }
 
@@ -636,7 +636,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -648,7 +648,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -667,7 +667,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU8, 0, 1)
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 1))
         );
     }
 
@@ -678,7 +678,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -689,7 +689,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -708,7 +708,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU16, 0, 1)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 1))
         );
     }
 
@@ -719,7 +719,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -730,7 +730,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -749,7 +749,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU32, 0, 1)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 1))
         );
     }
 
@@ -760,7 +760,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -771,7 +771,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -790,7 +790,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU64, 0, 1)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 1))
         );
     }
 
@@ -801,7 +801,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -812,7 +812,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -833,7 +833,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU128, 0, 1)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 1))
         );
     }
 
@@ -845,7 +845,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 4)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 4))
         );
     }
 
@@ -857,7 +857,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 4)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 4))
         );
     }
 
@@ -876,7 +876,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF32, 0, 1)
+            Error::new(error::Kind::ExpectedF32, Position::new(0, 1))
         );
     }
 
@@ -887,7 +887,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 6)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
         );
     }
 
@@ -898,7 +898,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 6)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
         );
     }
 
@@ -917,7 +917,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF64, 0, 1)
+            Error::new(error::Kind::ExpectedF64, Position::new(0, 1))
         );
     }
 
@@ -928,7 +928,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 6)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
         );
     }
 
@@ -939,7 +939,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 6)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
         );
     }
 
@@ -958,7 +958,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedChar, 0, 1)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 1))
         );
     }
 
@@ -969,7 +969,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 3)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 3))
         );
     }
 
@@ -980,7 +980,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 3)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 3))
         );
     }
 
@@ -999,7 +999,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedString, 0, 1)
+            Error::new(error::Kind::ExpectedString, Position::new(0, 1))
         );
     }
 
@@ -1010,7 +1010,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1021,7 +1021,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -1040,7 +1040,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1051,7 +1051,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -1070,7 +1070,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 1)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 1))
         );
     }
 
@@ -1081,7 +1081,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 2)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 2))
         );
     }
 
@@ -1092,7 +1092,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 2)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 2))
         );
     }
 
@@ -1115,7 +1115,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 1)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 1))
         );
     }
 
@@ -1128,7 +1128,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 2)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 2))
         );
     }
 
@@ -1141,7 +1141,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 2)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 2))
         );
     }
 
@@ -1173,7 +1173,7 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 13)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 13))
         );
     }
 
@@ -1184,7 +1184,7 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 13)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 13))
         );
     }
 
@@ -1210,7 +1210,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 13)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 13))
         );
     }
 
@@ -1223,7 +1223,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 13)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 13))
         );
     }
 
@@ -1286,7 +1286,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1301,7 +1301,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 9)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
         );
     }
 
@@ -1328,7 +1328,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 12)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 12))
         );
     }
 
@@ -1343,7 +1343,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 12)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 12))
         );
     }
 
@@ -1373,7 +1373,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 21)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 21))
         );
     }
 
@@ -1388,7 +1388,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 21)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 21))
         );
     }
 
@@ -1450,7 +1450,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedIdentifier, 0, 1)
+            Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 1))
         );
     }
 
@@ -1461,7 +1461,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 5)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -1472,7 +1472,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 5)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 }

--- a/src/de/struct/field.rs
+++ b/src/de/struct/field.rs
@@ -8,7 +8,10 @@ pub(in super::super) struct Deserializer<'a> {
 
 impl<'a> Deserializer<'a> {
     pub(in super::super) fn new(identifier: &'a str, position: Position) -> Self {
-        Self { identifier, position }
+        Self {
+            identifier,
+            position,
+        }
     }
 }
 
@@ -239,10 +242,12 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_str(self.identifier).map_err(|mut error: Error| {
-            error.set_position(self.position);
-            error
-        })
+        visitor
+            .visit_str(self.identifier)
+            .map_err(|mut error: Error| {
+                error.set_position(self.position);
+                error
+            })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -256,8 +261,8 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
 #[cfg(test)]
 mod tests {
     use super::Deserializer;
-    use claim::{assert_err_eq, assert_ok_eq};
     use crate::de::{error, Error, Position};
+    use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use std::fmt;
 

--- a/src/de/struct/mod.rs
+++ b/src/de/struct/mod.rs
@@ -48,11 +48,12 @@ where
             Err(_) => return Ok(None),
         };
         let mut values = tag.next()?;
-        let field = values.next()?.parse_identifier()?;
+        let value = values.next()?;
+        let field = value.parse_identifier()?;
 
         // Only return the result if the field is in the list of possible fields for the struct.
         if let Some(static_field) = self.fields.take(field.as_str()) {
-            let result = seed.deserialize(field::Deserializer::new(&field))?;
+            let result = seed.deserialize(field::Deserializer::new(&field, value.position()))?;
             // Note that these raw values will only live until the next call to `next_key_seed()`, at
             // which point they will be overwritten.
             self.values = Some(values.into_stored());
@@ -104,11 +105,12 @@ where
             Err(_) => return Ok(None),
         };
         let mut values = tag.next()?;
-        let field = values.next()?.parse_identifier()?;
+        let value = values.next()?;
+        let field = value.parse_identifier()?;
 
         // Only return the result if the field is in the list of possible fields for the struct.
         if let Some(static_field) = self.fields.take(field.as_str()) {
-            let key = key_seed.deserialize(field::Deserializer::new(&field))?;
+            let key = key_seed.deserialize(field::Deserializer::new(&field, value.position()))?;
             let stored_tag = tag.into_stored();
             let stored_values = values.into_stored();
             let value = value_seed.deserialize(value::Deserializer::new(

--- a/src/de/struct/mod.rs
+++ b/src/de/struct/mod.rs
@@ -131,7 +131,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::{parse::{Tag, Tags}, Position};
+    use crate::de::{
+        parse::{Tag, Tags},
+        Position,
+    };
     use claim::{assert_none, assert_ok, assert_ok_eq, assert_some_eq};
     use serde::{
         de,

--- a/src/de/struct/mod.rs
+++ b/src/de/struct/mod.rs
@@ -131,7 +131,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::parse::{Tag, Tags};
+    use crate::de::{parse::{Tag, Tags}, Position};
     use claim::{assert_none, assert_ok, assert_ok_eq, assert_some_eq};
     use serde::{
         de,
@@ -207,7 +207,7 @@ mod tests {
         assert_none!(assert_ok!(access.next_key::<Identifier>()));
 
         // Should also revisit the tag.
-        assert_ok_eq!(tags.next(), Tag::new(b"bar:42;\n", 0, 0));
+        assert_ok_eq!(tags.next(), Tag::new(b"bar:42;\n", Position::new(0, 0)));
     }
 
     #[test]
@@ -248,6 +248,6 @@ mod tests {
         assert_none!(assert_ok!(access.next_entry::<Identifier, u64>()));
 
         // Should also revisit the tag.
-        assert_ok_eq!(tags.next(), Tag::new(b"bar:42;\n", 0, 0));
+        assert_ok_eq!(tags.next(), Tag::new(b"bar:42;\n", Position::new(0, 0)));
     }
 }

--- a/src/de/struct/value.rs
+++ b/src/de/struct/value.rs
@@ -401,7 +401,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Deserializer;
-    use crate::de::{error, parse::Tags, Error};
+    use crate::de::{error, parse::Tags, Error, Position};
     use claim::{assert_err_eq, assert_ok, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use serde_bytes::ByteBuf;
@@ -446,7 +446,7 @@ mod tests {
 
         assert_err_eq!(
             bool::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedBool, 0, 5)
+            Error::new(error::Kind::ExpectedBool, Position::new(0, 5))
         );
     }
 
@@ -462,7 +462,7 @@ mod tests {
 
         assert_err_eq!(
             bool::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 10)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 10))
         );
     }
 
@@ -478,7 +478,7 @@ mod tests {
 
         assert_err_eq!(
             bool::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 10)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 10))
         );
     }
 
@@ -507,7 +507,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 5)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 5))
         );
     }
 
@@ -523,7 +523,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -539,7 +539,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -568,7 +568,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 5)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 5))
         );
     }
 
@@ -584,7 +584,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -600,7 +600,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -629,7 +629,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI32, 0, 5)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 5))
         );
     }
 
@@ -645,7 +645,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -661,7 +661,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -690,7 +690,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 5)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 5))
         );
     }
 
@@ -706,7 +706,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -722,7 +722,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -753,7 +753,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 5)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 5))
         );
     }
 
@@ -770,7 +770,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -787,7 +787,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -816,7 +816,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU8, 0, 5)
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 5))
         );
     }
 
@@ -832,7 +832,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -848,7 +848,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -877,7 +877,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU16, 0, 5)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 5))
         );
     }
 
@@ -893,7 +893,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -909,7 +909,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -938,7 +938,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU32, 0, 5)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 5))
         );
     }
 
@@ -954,7 +954,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -970,7 +970,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -999,7 +999,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU64, 0, 5)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 5))
         );
     }
 
@@ -1015,7 +1015,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -1031,7 +1031,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -1062,7 +1062,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU128, 0, 5)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 5))
         );
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 8)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -1096,7 +1096,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 8)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
         );
     }
 
@@ -1125,7 +1125,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF32, 0, 5)
+            Error::new(error::Kind::ExpectedF32, Position::new(0, 5))
         );
     }
 
@@ -1141,7 +1141,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 10)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 10))
         );
     }
 
@@ -1157,7 +1157,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 10)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 10))
         );
     }
 
@@ -1186,7 +1186,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF64, 0, 5)
+            Error::new(error::Kind::ExpectedF64, Position::new(0, 5))
         );
     }
 
@@ -1202,7 +1202,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 10)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 10))
         );
     }
 
@@ -1218,7 +1218,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 10)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 10))
         );
     }
 
@@ -1247,7 +1247,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedChar, 0, 5)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 5))
         );
     }
 
@@ -1263,7 +1263,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 7)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 7))
         );
     }
 
@@ -1279,7 +1279,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 7)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 7))
         );
     }
 
@@ -1308,7 +1308,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedString, 0, 5)
+            Error::new(error::Kind::ExpectedString, Position::new(0, 5))
         );
     }
 
@@ -1324,7 +1324,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1340,7 +1340,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 9)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
         );
     }
 
@@ -1369,7 +1369,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1385,7 +1385,7 @@ mod tests {
 
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 9)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
         );
     }
 
@@ -1427,7 +1427,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 5)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 5))
         );
     }
 
@@ -1443,7 +1443,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 6)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
         );
     }
 
@@ -1459,7 +1459,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 6)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
         );
     }
 
@@ -1492,7 +1492,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 5)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 5))
         );
     }
 
@@ -1510,7 +1510,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 6)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
         );
     }
 
@@ -1528,7 +1528,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 6)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
         );
     }
 
@@ -1573,7 +1573,7 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 17)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 17))
         );
     }
 
@@ -1589,7 +1589,7 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 17)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 17))
         );
     }
 
@@ -1625,7 +1625,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 17)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 17))
         );
     }
 
@@ -1643,7 +1643,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 17)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 17))
         );
     }
 
@@ -1698,7 +1698,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 13)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 13))
         );
     }
 
@@ -1718,7 +1718,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 13)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 13))
         );
     }
 
@@ -1755,7 +1755,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 16)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 16))
         );
     }
 
@@ -1775,7 +1775,7 @@ mod tests {
 
         assert_err_eq!(
             Newtype::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 16)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 16))
         );
     }
 
@@ -1815,7 +1815,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 25)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 25))
         );
     }
 
@@ -1835,7 +1835,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 25)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 25))
         );
     }
 
@@ -1896,7 +1896,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedIdentifier, 0, 5)
+            Error::new(error::Kind::ExpectedIdentifier, Position::new(0, 5))
         );
     }
 
@@ -1912,7 +1912,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, 0, 9)
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
         );
     }
 
@@ -1928,7 +1928,7 @@ mod tests {
 
         assert_err_eq!(
             Identifier::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, 0, 9)
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
         );
     }
 }

--- a/src/de/struct/value.rs
+++ b/src/de/struct/value.rs
@@ -49,10 +49,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_bool()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_bool(parsed)
+        visitor.visit_bool(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
@@ -61,10 +65,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i8()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_i8(parsed)
+        visitor.visit_i8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
@@ -73,10 +81,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i16()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_i16(parsed)
+        visitor.visit_i16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
@@ -85,10 +97,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i32()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_i32(parsed)
+        visitor.visit_i32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
@@ -97,10 +113,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i64()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_i64(parsed)
+        visitor.visit_i64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -110,10 +130,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_i128()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_i128(parsed)
+        visitor.visit_i128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -122,10 +146,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u8()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_u8(parsed)
+        visitor.visit_u8(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
@@ -134,10 +162,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u16()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_u16(parsed)
+        visitor.visit_u16(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
@@ -146,10 +178,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u32()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_u32(parsed)
+        visitor.visit_u32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
@@ -158,10 +194,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u64()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_u64(parsed)
+        visitor.visit_u64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -171,10 +211,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_u128()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_u128(parsed)
+        visitor.visit_u128(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -183,10 +227,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_f32()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_f32(parsed)
+        visitor.visit_f32(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
@@ -195,10 +243,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_f64()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_f64(parsed)
+        visitor.visit_f64(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
@@ -207,10 +259,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_char()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_char(parsed)
+        visitor.visit_char(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -219,10 +275,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_string()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
@@ -231,10 +291,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_string()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_string(parsed)
+        visitor.visit_string(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
@@ -243,10 +307,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_byte_buf();
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_bytes(&parsed)
+        visitor.visit_bytes(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -255,10 +323,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_byte_buf();
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_byte_buf(parsed)
+        visitor.visit_byte_buf(parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
@@ -275,10 +347,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         value.parse_unit()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -287,10 +363,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         value.parse_unit()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_unit()
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -384,10 +464,14 @@ where
     {
         let mut values = unsafe { self.values.into_values() };
         let value = values.next()?;
+        let value_position = value.position();
         let parsed = value.parse_identifier()?;
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
-        visitor.visit_str(&parsed)
+        visitor.visit_str(&parsed).map_err(|mut error: Error| {
+            error.set_position(value_position);
+            error
+        })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -483,6 +567,51 @@ mod tests {
     }
 
     #[test]
+    fn bool_custom_error() {
+        #[derive(Debug)]
+        struct CustomBool;
+
+        impl<'de> Deserialize<'de> for CustomBool {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomBoolVisitor;
+
+                impl<'de> Visitor<'de> for CustomBoolVisitor {
+                    type Value = CustomBool;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_bool(CustomBoolVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:true;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomBool::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn i8() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -540,6 +669,51 @@ mod tests {
         assert_err_eq!(
             i8::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
+    fn i8_custom_error() {
+        #[derive(Debug)]
+        struct CustomI8;
+
+        impl<'de> Deserialize<'de> for CustomI8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI8Visitor;
+
+                impl<'de> Visitor<'de> for CustomI8Visitor {
+                    type Value = CustomI8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i8<E>(self, _value: i8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i8(CustomI8Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomI8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -605,6 +779,51 @@ mod tests {
     }
 
     #[test]
+    fn i16_custom_error() {
+        #[derive(Debug)]
+        struct CustomI16;
+
+        impl<'de> Deserialize<'de> for CustomI16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI16Visitor;
+
+                impl<'de> Visitor<'de> for CustomI16Visitor {
+                    type Value = CustomI16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i16<E>(self, _value: i16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i16(CustomI16Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomI16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn i32() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -666,6 +885,51 @@ mod tests {
     }
 
     #[test]
+    fn i32_custom_error() {
+        #[derive(Debug)]
+        struct CustomI32;
+
+        impl<'de> Deserialize<'de> for CustomI32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI32Visitor;
+
+                impl<'de> Visitor<'de> for CustomI32Visitor {
+                    type Value = CustomI32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i32<E>(self, _value: i32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i32(CustomI32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomI32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn i64() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -723,6 +987,51 @@ mod tests {
         assert_err_eq!(
             i64::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
+    fn i64_custom_error() {
+        #[derive(Debug)]
+        struct CustomI64;
+
+        impl<'de> Deserialize<'de> for CustomI64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI64Visitor;
+
+                impl<'de> Visitor<'de> for CustomI64Visitor {
+                    type Value = CustomI64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i64(CustomI64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomI64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -792,6 +1101,51 @@ mod tests {
     }
 
     #[test]
+    fn i128_custom_error() {
+        #[derive(Debug)]
+        struct CustomI128;
+
+        impl<'de> Deserialize<'de> for CustomI128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI128Visitor;
+
+                impl<'de> Visitor<'de> for CustomI128Visitor {
+                    type Value = CustomI128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i128<E>(self, _value: i128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i128(CustomI128Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomI128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn u8() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -849,6 +1203,51 @@ mod tests {
         assert_err_eq!(
             u8::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
+    fn u8_custom_error() {
+        #[derive(Debug)]
+        struct CustomU8;
+
+        impl<'de> Deserialize<'de> for CustomU8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU8Visitor;
+
+                impl<'de> Visitor<'de> for CustomU8Visitor {
+                    type Value = CustomU8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u8<E>(self, _value: u8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u8(CustomU8Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomU8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -914,6 +1313,51 @@ mod tests {
     }
 
     #[test]
+    fn u16_custom_error() {
+        #[derive(Debug)]
+        struct CustomU16;
+
+        impl<'de> Deserialize<'de> for CustomU16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU16Visitor;
+
+                impl<'de> Visitor<'de> for CustomU16Visitor {
+                    type Value = CustomU16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u16<E>(self, _value: u16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u16(CustomU16Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomU16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn u32() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -975,6 +1419,51 @@ mod tests {
     }
 
     #[test]
+    fn u32_custom_error() {
+        #[derive(Debug)]
+        struct CustomU32;
+
+        impl<'de> Deserialize<'de> for CustomU32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU32Visitor;
+
+                impl<'de> Visitor<'de> for CustomU32Visitor {
+                    type Value = CustomU32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u32<E>(self, _value: u32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u32(CustomU32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomU32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn u64() {
         let mut tags = Tags::new(b"#foo:42;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -1032,6 +1521,51 @@ mod tests {
         assert_err_eq!(
             u64::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
+    fn u64_custom_error() {
+        #[derive(Debug)]
+        struct CustomU64;
+
+        impl<'de> Deserialize<'de> for CustomU64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU64Visitor;
+
+                impl<'de> Visitor<'de> for CustomU64Visitor {
+                    type Value = CustomU64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u64(CustomU64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomU64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -1101,6 +1635,51 @@ mod tests {
     }
 
     #[test]
+    fn u128_custom_error() {
+        #[derive(Debug)]
+        struct CustomU128;
+
+        impl<'de> Deserialize<'de> for CustomU128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU128Visitor;
+
+                impl<'de> Visitor<'de> for CustomU128Visitor {
+                    type Value = CustomU128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u128<E>(self, _value: u128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u128(CustomU128Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomU128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn f32() {
         let mut tags = Tags::new(b"#foo:42.9;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -1158,6 +1737,51 @@ mod tests {
         assert_err_eq!(
             f32::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 10))
+        );
+    }
+
+    #[test]
+    fn f32_custom_error() {
+        #[derive(Debug)]
+        struct CustomF32;
+
+        impl<'de> Deserialize<'de> for CustomF32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF32Visitor;
+
+                impl<'de> Visitor<'de> for CustomF32Visitor {
+                    type Value = CustomF32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f32<E>(self, _value: f32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f32(CustomF32Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42.9;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomF32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -1223,6 +1847,51 @@ mod tests {
     }
 
     #[test]
+    fn f64_custom_error() {
+        #[derive(Debug)]
+        struct CustomF64;
+
+        impl<'de> Deserialize<'de> for CustomF64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF64Visitor;
+
+                impl<'de> Visitor<'de> for CustomF64Visitor {
+                    type Value = CustomF64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f64(CustomF64Visitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:42.9;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomF64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn char() {
         let mut tags = Tags::new(b"#foo:a;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -1280,6 +1949,51 @@ mod tests {
         assert_err_eq!(
             char::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 7))
+        );
+    }
+
+    #[test]
+    fn char_custom_error() {
+        #[derive(Debug)]
+        struct CustomChar;
+
+        impl<'de> Deserialize<'de> for CustomChar {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomCharVisitor;
+
+                impl<'de> Visitor<'de> for CustomCharVisitor {
+                    type Value = CustomChar;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_char<E>(self, _value: char) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_char(CustomCharVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:a;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomChar::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -1345,6 +2059,51 @@ mod tests {
     }
 
     #[test]
+    fn string_custom_error() {
+        #[derive(Debug)]
+        struct CustomString;
+
+        impl<'de> Deserialize<'de> for CustomString {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomStringVisitor;
+
+                impl<'de> Visitor<'de> for CustomStringVisitor {
+                    type Value = CustomString;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_string(CustomStringVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:foo;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomString::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn bytes() {
         let mut tags = Tags::new(b"#foo:foo;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
@@ -1386,6 +2145,51 @@ mod tests {
         assert_err_eq!(
             ByteBuf::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
+        );
+    }
+
+    #[test]
+    fn byte_buf_custom_error() {
+        #[derive(Debug)]
+        struct CustomByteBuf;
+
+        impl<'de> Deserialize<'de> for CustomByteBuf {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomByteBufVisitor;
+
+                impl<'de> Visitor<'de> for CustomByteBufVisitor {
+                    type Value = CustomByteBuf;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_byte_buf<E>(self, _value: Vec<u8>) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_byte_buf(CustomByteBufVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:foo;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomByteBuf::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -1464,6 +2268,51 @@ mod tests {
     }
 
     #[test]
+    fn unit_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnit;
+
+        impl<'de> Deserialize<'de> for CustomUnit {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitVisitor {
+                    type Value = CustomUnit;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit(CustomUnitVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomUnit::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+        );
+    }
+
+    #[test]
     fn unit_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
@@ -1529,6 +2378,51 @@ mod tests {
         assert_err_eq!(
             Unit::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
+        );
+    }
+
+    #[test]
+    fn unit_struct_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnitStruct;
+
+        impl<'de> Deserialize<'de> for CustomUnitStruct {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitStructVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitStructVisitor {
+                    type Value = CustomUnitStruct;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit_struct("CustomUnitStruct", CustomUnitStructVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomUnitStruct::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 
@@ -1929,6 +2823,51 @@ mod tests {
         assert_err_eq!(
             Identifier::deserialize(deserializer),
             Error::new(error::Kind::UnexpectedValues, Position::new(0, 9))
+        );
+    }
+
+    #[test]
+    fn identifier_custom_error() {
+        #[derive(Debug)]
+        struct CustomIdentifier;
+
+        impl<'de> Deserialize<'de> for CustomIdentifier {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomIdentifierVisitor;
+
+                impl<'de> Visitor<'de> for CustomIdentifierVisitor {
+                    type Value = CustomIdentifier;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_identifier(CustomIdentifierVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo:foo;\n".as_slice());
+        let mut tag = assert_ok!(tags.next());
+        let mut values = assert_ok!(tag.next());
+        let _field = assert_ok!(values.next());
+        let stored_tag = tag.into_stored();
+        let stored_values = values.into_stored();
+        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
+
+        assert_err_eq!(
+            CustomIdentifier::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
         );
     }
 }

--- a/src/de/tuple/element.rs
+++ b/src/de/tuple/element.rs
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn i8_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i8::deserialize(deserializer), 42);
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn i8_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn i8_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i8::deserialize(deserializer), 42);
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn i16_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i16::deserialize(deserializer), 42);
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn i16_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn i16_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i16::deserialize(deserializer), 42);
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn i32_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i32::deserialize(deserializer), 42);
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn i32_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn i32_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i32::deserialize(deserializer), 42);
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn i64_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i64::deserialize(deserializer), 42);
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn i64_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn i64_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i64::deserialize(deserializer), 42);
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(has_i128), ignore)]
     fn i128_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i128::deserialize(deserializer), 42);
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(has_i128), ignore)]
     fn i128_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -398,7 +398,7 @@ mod tests {
     #[cfg_attr(not(has_i128), ignore)]
     fn i128_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i128::deserialize(deserializer), 42);
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn u8_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u8::deserialize(deserializer), 42);
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn u8_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -426,7 +426,7 @@ mod tests {
     #[test]
     fn u8_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u8::deserialize(deserializer), 42);
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn u16_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u16::deserialize(deserializer), 42);
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn u16_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -454,7 +454,7 @@ mod tests {
     #[test]
     fn u16_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u16::deserialize(deserializer), 42);
@@ -462,7 +462,7 @@ mod tests {
 
     #[test]
     fn u32_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u32::deserialize(deserializer), 42);
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn u32_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn u32_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u32::deserialize(deserializer), 42);
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn u64_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u64::deserialize(deserializer), 42);
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn u64_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn u64_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u64::deserialize(deserializer), 42);
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(has_i128), ignore)]
     fn u128_valid() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u128::deserialize(deserializer), 42);
@@ -528,7 +528,7 @@ mod tests {
     #[test]
     #[cfg_attr(not(has_i128), ignore)]
     fn u128_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -541,7 +541,7 @@ mod tests {
     #[cfg_attr(not(has_i128), ignore)]
     fn u128_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u128::deserialize(deserializer), 42);
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     fn f32_valid() {
-        let mut values = Values::new(b"42.9", 0, 0);
+        let mut values = Values::new(b"42.9", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(f32::deserialize(deserializer), 42.9);
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn f32_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     fn f32_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42.9:100.1", 0, 0);
+        let mut values = Values::new(b"42.9:100.1", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(f32::deserialize(deserializer), 42.9);
@@ -577,7 +577,7 @@ mod tests {
 
     #[test]
     fn f64_valid() {
-        let mut values = Values::new(b"42.9", 0, 0);
+        let mut values = Values::new(b"42.9", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(f64::deserialize(deserializer), 42.9);
@@ -585,7 +585,7 @@ mod tests {
 
     #[test]
     fn f64_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn f64_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42.9:100.1", 0, 0);
+        let mut values = Values::new(b"42.9:100.1", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(f64::deserialize(deserializer), 42.9);
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn char_valid() {
-        let mut values = Values::new(b"a", 0, 0);
+        let mut values = Values::new(b"a", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(char::deserialize(deserializer), 'a');
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn char_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -625,7 +625,7 @@ mod tests {
     #[test]
     fn char_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"a:b", 0, 0);
+        let mut values = Values::new(b"a:b", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(char::deserialize(deserializer), 'a');
@@ -633,7 +633,7 @@ mod tests {
 
     #[test]
     fn string_valid() {
-        let mut values = Values::new(b"foo", 0, 0);
+        let mut values = Values::new(b"foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(String::deserialize(deserializer), "foo");
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn string_invalid() {
-        let mut values = Values::new(b"\xF0\x9Ffoo", 0, 0);
+        let mut values = Values::new(b"\xF0\x9Ffoo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -653,7 +653,7 @@ mod tests {
     #[test]
     fn string_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"foo:bar", 0, 0);
+        let mut values = Values::new(b"foo:bar", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(String::deserialize(deserializer), "foo");
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn byte_buf() {
-        let mut values = Values::new(b"foo", 0, 0);
+        let mut values = Values::new(b"foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(ByteBuf::deserialize(deserializer), b"foo");
@@ -670,7 +670,7 @@ mod tests {
     #[test]
     fn byte_buf_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"foo:bar", 0, 0);
+        let mut values = Values::new(b"foo:bar", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(ByteBuf::deserialize(deserializer), b"foo");
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn unit() {
-        let mut values = Values::new(b"", 0, 0);
+        let mut values = Values::new(b"", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(<()>::deserialize(deserializer), ());
@@ -686,7 +686,7 @@ mod tests {
 
     #[test]
     fn unit_invalid() {
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -698,7 +698,7 @@ mod tests {
     #[test]
     fn unit_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b":", 0, 0);
+        let mut values = Values::new(b":", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(<()>::deserialize(deserializer), ());
@@ -708,7 +708,7 @@ mod tests {
     fn unit_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
-        let mut values = Values::new(b"", 0, 0);
+        let mut values = Values::new(b"", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit);
@@ -718,7 +718,7 @@ mod tests {
     fn unit_struct_invalid() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
-        let mut values = Values::new(b"invalid", 0, 0);
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -732,7 +732,7 @@ mod tests {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b":", 0, 0);
+        let mut values = Values::new(b":", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit);
@@ -742,7 +742,7 @@ mod tests {
     fn newtype_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Newtype(u64);
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Newtype::deserialize(deserializer), Newtype(42));
@@ -753,7 +753,7 @@ mod tests {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Newtype(u64);
         // The entire values iterator is not consumed. Just the first value is returned.
-        let mut values = Values::new(b"42:100", 0, 0);
+        let mut values = Values::new(b"42:100", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Newtype::deserialize(deserializer), Newtype(42));
@@ -761,7 +761,7 @@ mod tests {
 
     #[test]
     fn tuple() {
-        let mut values = Values::new(b"42:foo::1.2", 0, 0);
+        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -774,7 +774,7 @@ mod tests {
     fn tuple_trailing_values() {
         // The entire values iterator is not consumed. Just the requested tuple values are
         // consumed.
-        let mut values = Values::new(b"42:foo::1.2:not:consumed", 0, 0);
+        let mut values = Values::new(b"42:foo::1.2:not:consumed", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -787,7 +787,7 @@ mod tests {
     fn tuple_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut values = Values::new(b"42:foo::1.2", 0, 0);
+        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -802,7 +802,7 @@ mod tests {
         struct TupleStruct(u64, String, (), f64);
         // The entire values iterator is not consumed. Just the requested tuple values are
         // consumed.
-        let mut values = Values::new(b"42:foo::1.2:not:consumed", 0, 0);
+        let mut values = Values::new(b"42:foo::1.2:not:consumed", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -817,7 +817,7 @@ mod tests {
         enum Unit {
             Variant,
         }
-        let mut values = Values::new(b"Variant", 0, 0);
+        let mut values = Values::new(b"Variant", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit::Variant,);
@@ -829,7 +829,7 @@ mod tests {
         enum Unit {
             Variant,
         }
-        let mut values = Values::new(b"Variant:42", 0, 0);
+        let mut values = Values::new(b"Variant:42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit::Variant,);
@@ -841,7 +841,7 @@ mod tests {
         enum Newtype {
             Variant(u64),
         }
-        let mut values = Values::new(b"Variant:42", 0, 0);
+        let mut values = Values::new(b"Variant:42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Newtype::deserialize(deserializer), Newtype::Variant(42),);
@@ -853,7 +853,7 @@ mod tests {
         enum Newtype {
             Variant(u64),
         }
-        let mut values = Values::new(b"Variant:42:foo", 0, 0);
+        let mut values = Values::new(b"Variant:42:foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Newtype::deserialize(deserializer), Newtype::Variant(42),);
@@ -865,7 +865,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String),
         }
-        let mut values = Values::new(b"Variant:42:foo", 0, 0);
+        let mut values = Values::new(b"Variant:42:foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -880,7 +880,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String),
         }
-        let mut values = Values::new(b"Variant:42:foo:bar", 0, 0);
+        let mut values = Values::new(b"Variant:42:foo:bar", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -920,7 +920,7 @@ mod tests {
 
     #[test]
     fn identifier() {
-        let mut values = Values::new(b"foo", 0, 0);
+        let mut values = Values::new(b"foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -931,7 +931,7 @@ mod tests {
 
     #[test]
     fn identifier_trailing_values() {
-        let mut values = Values::new(b"foo:bar", 0, 0);
+        let mut values = Values::new(b"foo:bar", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(

--- a/src/de/tuple/element.rs
+++ b/src/de/tuple/element.rs
@@ -254,7 +254,7 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::Deserializer;
-    use crate::de::{error, parse::Values, Error};
+    use crate::de::{error, parse::Values, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
     use serde_bytes::ByteBuf;
@@ -276,7 +276,7 @@ mod tests {
 
         assert_err_eq!(
             i8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI8, 0, 0)
+            Error::new(error::Kind::ExpectedI8, Position::new(0, 0))
         );
     }
 
@@ -304,7 +304,7 @@ mod tests {
 
         assert_err_eq!(
             i16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI16, 0, 0)
+            Error::new(error::Kind::ExpectedI16, Position::new(0, 0))
         );
     }
 
@@ -332,7 +332,7 @@ mod tests {
 
         assert_err_eq!(
             i32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI32, 0, 0)
+            Error::new(error::Kind::ExpectedI32, Position::new(0, 0))
         );
     }
 
@@ -360,7 +360,7 @@ mod tests {
 
         assert_err_eq!(
             i64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI64, 0, 0)
+            Error::new(error::Kind::ExpectedI64, Position::new(0, 0))
         );
     }
 
@@ -390,7 +390,7 @@ mod tests {
 
         assert_err_eq!(
             i128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedI128, 0, 0)
+            Error::new(error::Kind::ExpectedI128, Position::new(0, 0))
         );
     }
 
@@ -419,7 +419,7 @@ mod tests {
 
         assert_err_eq!(
             u8::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU8, 0, 0)
+            Error::new(error::Kind::ExpectedU8, Position::new(0, 0))
         );
     }
 
@@ -447,7 +447,7 @@ mod tests {
 
         assert_err_eq!(
             u16::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU16, 0, 0)
+            Error::new(error::Kind::ExpectedU16, Position::new(0, 0))
         );
     }
 
@@ -475,7 +475,7 @@ mod tests {
 
         assert_err_eq!(
             u32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU32, 0, 0)
+            Error::new(error::Kind::ExpectedU32, Position::new(0, 0))
         );
     }
 
@@ -503,7 +503,7 @@ mod tests {
 
         assert_err_eq!(
             u64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU64, 0, 0)
+            Error::new(error::Kind::ExpectedU64, Position::new(0, 0))
         );
     }
 
@@ -533,7 +533,7 @@ mod tests {
 
         assert_err_eq!(
             u128::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedU128, 0, 0)
+            Error::new(error::Kind::ExpectedU128, Position::new(0, 0))
         );
     }
 
@@ -562,7 +562,7 @@ mod tests {
 
         assert_err_eq!(
             f32::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF32, 0, 0)
+            Error::new(error::Kind::ExpectedF32, Position::new(0, 0))
         );
     }
 
@@ -590,7 +590,7 @@ mod tests {
 
         assert_err_eq!(
             f64::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedF64, 0, 0)
+            Error::new(error::Kind::ExpectedF64, Position::new(0, 0))
         );
     }
 
@@ -618,7 +618,7 @@ mod tests {
 
         assert_err_eq!(
             char::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedChar, 0, 0)
+            Error::new(error::Kind::ExpectedChar, Position::new(0, 0))
         );
     }
 
@@ -646,7 +646,7 @@ mod tests {
 
         assert_err_eq!(
             String::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedString, 0, 0)
+            Error::new(error::Kind::ExpectedString, Position::new(0, 0))
         );
     }
 
@@ -691,7 +691,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 0)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 0))
         );
     }
 
@@ -723,7 +723,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, 0, 0)
+            Error::new(error::Kind::ExpectedUnit, Position::new(0, 0))
         );
     }
 

--- a/src/de/tuple/element.rs
+++ b/src/de/tuple/element.rs
@@ -25,35 +25,55 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bool(self.values.next()?.parse_bool()?)
+        let value = self.values.next()?;
+        visitor.visit_bool(value.parse_bool()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i8(self.values.next()?.parse_i8()?)
+        let value = self.values.next()?;
+        visitor.visit_i8(value.parse_i8()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i16(self.values.next()?.parse_i16()?)
+        let value = self.values.next()?;
+        visitor.visit_i16(value.parse_i16()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i32(self.values.next()?.parse_i32()?)
+        let value = self.values.next()?;
+        visitor.visit_i32(value.parse_i32()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i64(self.values.next()?.parse_i64()?)
+        let value = self.values.next()?;
+        visitor.visit_i64(value.parse_i64()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -61,35 +81,55 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_i128(self.values.next()?.parse_i128()?)
+        let value = self.values.next()?;
+        visitor.visit_i128(value.parse_i128()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(self.values.next()?.parse_u8()?)
+        let value = self.values.next()?;
+        visitor.visit_u8(value.parse_u8()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u16(self.values.next()?.parse_u16()?)
+        let value = self.values.next()?;
+        visitor.visit_u16(value.parse_u16()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u32(self.values.next()?.parse_u32()?)
+        let value = self.values.next()?;
+        visitor.visit_u32(value.parse_u32()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u64(self.values.next()?.parse_u64()?)
+        let value = self.values.next()?;
+        visitor.visit_u64(value.parse_u64()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     #[cfg(has_i128)]
@@ -97,56 +137,88 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u128(self.values.next()?.parse_u128()?)
+        let value = self.values.next()?;
+        visitor.visit_u128(value.parse_u128()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f32(self.values.next()?.parse_f32()?)
+        let value = self.values.next()?;
+        visitor.visit_f32(value.parse_f32()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_f64(self.values.next()?.parse_f64()?)
+        let value = self.values.next()?;
+        visitor.visit_f64(value.parse_f64()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_char(self.values.next()?.parse_char()?)
+        let value = self.values.next()?;
+        visitor.visit_char(value.parse_char()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_str(&self.values.next()?.parse_string()?)
+        let value = self.values.next()?;
+        visitor.visit_str(&value.parse_string()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_string(self.values.next()?.parse_string()?)
+        let value = self.values.next()?;
+        visitor.visit_string(value.parse_string()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_bytes(&self.values.next()?.parse_byte_buf())
+        let value = self.values.next()?;
+        visitor.visit_bytes(&value.parse_byte_buf()).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_byte_buf(self.values.next()?.parse_byte_buf())
+        let value = self.values.next()?;
+        visitor.visit_byte_buf(value.parse_byte_buf()).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
@@ -160,16 +232,24 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        self.values.next()?.parse_unit()?;
-        visitor.visit_unit()
+        let value = self.values.next()?;
+        value.parse_unit()?;
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        self.values.next()?.parse_unit()?;
-        visitor.visit_unit()
+        let value = self.values.next()?;
+        value.parse_unit()?;
+        visitor.visit_unit().map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
@@ -240,7 +320,11 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_str(&self.values.next()?.parse_identifier()?)
+        let value = self.values.next()?;
+        visitor.visit_str(&value.parse_identifier()?).map_err(|mut error: Error| {
+            error.set_position(value.position());
+            error
+        })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -260,6 +344,79 @@ mod tests {
     use serde_bytes::ByteBuf;
     use serde_derive::Deserialize;
     use std::fmt;
+
+    #[test]
+    fn bool_true() {
+        let mut values = Values::new(b"true", Position::new(0, 0));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_ok_eq!(bool::deserialize(deserializer), true);
+    }
+
+    #[test]
+    fn bool_false() {
+        let mut values = Values::new(b"false", Position::new(0, 0));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_ok_eq!(bool::deserialize(deserializer), false);
+    }
+
+    #[test]
+    fn bool_invalid() {
+        let mut values = Values::new(b"invalid", Position::new(0, 0));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(bool::deserialize(deserializer), Error::new(error::Kind::ExpectedBool, Position::new(0, 0)));
+    }
+
+    #[test]
+    fn bool_multiple_values() {
+        // The entire values iterator is not consumed. Just the first value is returned.
+        let mut values = Values::new(b"true:false", Position::new(0, 0));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_ok_eq!(bool::deserialize(deserializer), true);
+    }
+
+    #[test]
+    fn bool_custom_error() {
+        #[derive(Debug)]
+        struct CustomBool;
+
+        impl<'de> Deserialize<'de> for CustomBool {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomBoolVisitor;
+
+                impl<'de> Visitor<'de> for CustomBoolVisitor {
+                    type Value = CustomBool;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_bool(CustomBoolVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"true", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomBool::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
 
     #[test]
     fn i8_valid() {
@@ -287,6 +444,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i8::deserialize(deserializer), 42);
+    }
+
+    #[test]
+    fn i8_custom_error() {
+        #[derive(Debug)]
+        struct CustomI8;
+
+        impl<'de> Deserialize<'de> for CustomI8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI8Visitor;
+
+                impl<'de> Visitor<'de> for CustomI8Visitor {
+                    type Value = CustomI8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i8<E>(self, _value: i8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i8(CustomI8Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomI8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -318,6 +515,46 @@ mod tests {
     }
 
     #[test]
+    fn i16_custom_error() {
+        #[derive(Debug)]
+        struct CustomI16;
+
+        impl<'de> Deserialize<'de> for CustomI16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI16Visitor;
+
+                impl<'de> Visitor<'de> for CustomI16Visitor {
+                    type Value = CustomI16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i16<E>(self, _value: i16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i16(CustomI16Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomI16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn i32_valid() {
         let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -346,6 +583,46 @@ mod tests {
     }
 
     #[test]
+    fn i32_custom_error() {
+        #[derive(Debug)]
+        struct CustomI32;
+
+        impl<'de> Deserialize<'de> for CustomI32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI32Visitor;
+
+                impl<'de> Visitor<'de> for CustomI32Visitor {
+                    type Value = CustomI32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i32<E>(self, _value: i32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i32(CustomI32Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomI32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn i64_valid() {
         let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -371,6 +648,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(i64::deserialize(deserializer), 42);
+    }
+
+    #[test]
+    fn i64_custom_error() {
+        #[derive(Debug)]
+        struct CustomI64;
+
+        impl<'de> Deserialize<'de> for CustomI64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI64Visitor;
+
+                impl<'de> Visitor<'de> for CustomI64Visitor {
+                    type Value = CustomI64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i64(CustomI64Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomI64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -405,6 +722,46 @@ mod tests {
     }
 
     #[test]
+    fn i128_custom_error() {
+        #[derive(Debug)]
+        struct CustomI128;
+
+        impl<'de> Deserialize<'de> for CustomI128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomI128Visitor;
+
+                impl<'de> Visitor<'de> for CustomI128Visitor {
+                    type Value = CustomI128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_i128<E>(self, _value: i128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_i128(CustomI128Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomI128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn u8_valid() {
         let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -430,6 +787,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u8::deserialize(deserializer), 42);
+    }
+
+    #[test]
+    fn u8_custom_error() {
+        #[derive(Debug)]
+        struct CustomU8;
+
+        impl<'de> Deserialize<'de> for CustomU8 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU8Visitor;
+
+                impl<'de> Visitor<'de> for CustomU8Visitor {
+                    type Value = CustomU8;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u8<E>(self, _value: u8) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u8(CustomU8Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomU8::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -461,6 +858,46 @@ mod tests {
     }
 
     #[test]
+    fn u16_custom_error() {
+        #[derive(Debug)]
+        struct CustomU16;
+
+        impl<'de> Deserialize<'de> for CustomU16 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU16Visitor;
+
+                impl<'de> Visitor<'de> for CustomU16Visitor {
+                    type Value = CustomU16;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u16<E>(self, _value: u16) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u16(CustomU16Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomU16::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn u32_valid() {
         let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -489,6 +926,46 @@ mod tests {
     }
 
     #[test]
+    fn u32_custom_error() {
+        #[derive(Debug)]
+        struct CustomU32;
+
+        impl<'de> Deserialize<'de> for CustomU32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU32Visitor;
+
+                impl<'de> Visitor<'de> for CustomU32Visitor {
+                    type Value = CustomU32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u32<E>(self, _value: u32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u32(CustomU32Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomU32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn u64_valid() {
         let mut values = Values::new(b"42", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -514,6 +991,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(u64::deserialize(deserializer), 42);
+    }
+
+    #[test]
+    fn u64_custom_error() {
+        #[derive(Debug)]
+        struct CustomU64;
+
+        impl<'de> Deserialize<'de> for CustomU64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU64Visitor;
+
+                impl<'de> Visitor<'de> for CustomU64Visitor {
+                    type Value = CustomU64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u64(CustomU64Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomU64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -548,6 +1065,46 @@ mod tests {
     }
 
     #[test]
+    fn u128_custom_error() {
+        #[derive(Debug)]
+        struct CustomU128;
+
+        impl<'de> Deserialize<'de> for CustomU128 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomU128Visitor;
+
+                impl<'de> Visitor<'de> for CustomU128Visitor {
+                    type Value = CustomU128;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_u128<E>(self, _value: u128) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_u128(CustomU128Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomU128::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn f32_valid() {
         let mut values = Values::new(b"42.9", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -573,6 +1130,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(f32::deserialize(deserializer), 42.9);
+    }
+
+    #[test]
+    fn f32_custom_error() {
+        #[derive(Debug)]
+        struct CustomF32;
+
+        impl<'de> Deserialize<'de> for CustomF32 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF32Visitor;
+
+                impl<'de> Visitor<'de> for CustomF32Visitor {
+                    type Value = CustomF32;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f32<E>(self, _value: f32) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f32(CustomF32Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomF32::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -604,6 +1201,46 @@ mod tests {
     }
 
     #[test]
+    fn f64_custom_error() {
+        #[derive(Debug)]
+        struct CustomF64;
+
+        impl<'de> Deserialize<'de> for CustomF64 {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomF64Visitor;
+
+                impl<'de> Visitor<'de> for CustomF64Visitor {
+                    type Value = CustomF64;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_f64(CustomF64Visitor)
+            }
+        }
+
+         let mut values = Values::new(b"42", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomF64::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn char_valid() {
         let mut values = Values::new(b"a", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -629,6 +1266,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(char::deserialize(deserializer), 'a');
+    }
+
+    #[test]
+    fn char_custom_error() {
+        #[derive(Debug)]
+        struct CustomChar;
+
+        impl<'de> Deserialize<'de> for CustomChar {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomCharVisitor;
+
+                impl<'de> Visitor<'de> for CustomCharVisitor {
+                    type Value = CustomChar;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_char<E>(self, _value: char) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_char(CustomCharVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"a", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomChar::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -660,6 +1337,46 @@ mod tests {
     }
 
     #[test]
+    fn string_custom_error() {
+        #[derive(Debug)]
+        struct CustomString;
+
+        impl<'de> Deserialize<'de> for CustomString {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomStringVisitor;
+
+                impl<'de> Visitor<'de> for CustomStringVisitor {
+                    type Value = CustomString;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_string(CustomStringVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"a", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomString::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
     fn byte_buf() {
         let mut values = Values::new(b"foo", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
@@ -674,6 +1391,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(ByteBuf::deserialize(deserializer), b"foo");
+    }
+
+    #[test]
+    fn byte_buf_custom_error() {
+        #[derive(Debug)]
+        struct CustomByteBuf;
+
+        impl<'de> Deserialize<'de> for CustomByteBuf {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomByteBufVisitor;
+
+                impl<'de> Visitor<'de> for CustomByteBufVisitor {
+                    type Value = CustomByteBuf;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_byte_buf<E>(self, _value: Vec<u8>) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_byte_buf(CustomByteBufVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"a", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomByteBuf::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -702,6 +1459,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(<()>::deserialize(deserializer), ());
+    }
+
+    #[test]
+    fn unit_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnit;
+
+        impl<'de> Deserialize<'de> for CustomUnit {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitVisitor {
+                    type Value = CustomUnit;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit(CustomUnitVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomUnit::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -736,6 +1533,46 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit);
+    }
+
+    #[test]
+    fn unit_struct_custom_error() {
+        #[derive(Debug)]
+        struct CustomUnitStruct;
+
+        impl<'de> Deserialize<'de> for CustomUnitStruct {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomUnitStructVisitor;
+
+                impl<'de> Visitor<'de> for CustomUnitStructVisitor {
+                    type Value = CustomUnitStruct;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_unit<E>(self) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_unit_struct("CustomUnitStruct", CustomUnitStructVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomUnitStruct::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
     }
 
     #[test]
@@ -937,6 +1774,46 @@ mod tests {
         assert_ok_eq!(
             Identifier::deserialize(deserializer),
             Identifier("foo".to_owned()),
+        );
+    }
+
+    #[test]
+    fn identifier_custom_error() {
+        #[derive(Debug)]
+        struct CustomIdentifier;
+
+        impl<'de> Deserialize<'de> for CustomIdentifier {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct CustomIdentifierVisitor;
+
+                impl<'de> Visitor<'de> for CustomIdentifierVisitor {
+                    type Value = CustomIdentifier;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+
+                    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E>
+                    where
+                        E: de::Error,
+                    {
+                        Err(de::Error::custom("foo"))
+                    }
+                }
+
+                deserializer.deserialize_identifier(CustomIdentifierVisitor)
+            }
+        }
+
+         let mut values = Values::new(b"a", Position::new(1, 2));
+        let deserializer = Deserializer::new(&mut values);
+
+        assert_err_eq!(
+            CustomIdentifier::deserialize(deserializer),
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
         );
     }
 }

--- a/src/de/tuple/element.rs
+++ b/src/de/tuple/element.rs
@@ -26,10 +26,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_bool(value.parse_bool()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_bool(value.parse_bool()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
@@ -37,10 +39,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_i8(value.parse_i8()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_i8(value.parse_i8()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
@@ -48,10 +52,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_i16(value.parse_i16()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_i16(value.parse_i16()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
@@ -59,10 +65,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_i32(value.parse_i32()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_i32(value.parse_i32()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
@@ -70,10 +78,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_i64(value.parse_i64()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_i64(value.parse_i64()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     #[cfg(has_i128)]
@@ -82,10 +92,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_i128(value.parse_i128()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_i128(value.parse_i128()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
@@ -93,10 +105,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_u8(value.parse_u8()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_u8(value.parse_u8()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
@@ -104,10 +118,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_u16(value.parse_u16()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_u16(value.parse_u16()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
@@ -115,10 +131,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_u32(value.parse_u32()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_u32(value.parse_u32()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
@@ -126,10 +144,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_u64(value.parse_u64()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_u64(value.parse_u64()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     #[cfg(has_i128)]
@@ -138,10 +158,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_u128(value.parse_u128()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_u128(value.parse_u128()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
@@ -149,10 +171,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_f32(value.parse_f32()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_f32(value.parse_f32()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
@@ -160,10 +184,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_f64(value.parse_f64()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_f64(value.parse_f64()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
@@ -171,10 +197,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_char(value.parse_char()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_char(value.parse_char()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -182,10 +210,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_str(&value.parse_string()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_str(&value.parse_string()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
@@ -193,10 +223,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_string(value.parse_string()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_string(value.parse_string()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
@@ -204,10 +236,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_bytes(&value.parse_byte_buf()).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_bytes(&value.parse_byte_buf())
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
@@ -215,10 +249,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_byte_buf(value.parse_byte_buf()).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_byte_buf(value.parse_byte_buf())
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
@@ -321,10 +357,12 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
         V: Visitor<'de>,
     {
         let value = self.values.next()?;
-        visitor.visit_str(&value.parse_identifier()?).map_err(|mut error: Error| {
-            error.set_position(value.position());
-            error
-        })
+        visitor
+            .visit_str(&value.parse_identifier()?)
+            .map_err(|mut error: Error| {
+                error.set_position(value.position());
+                error
+            })
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -366,7 +404,10 @@ mod tests {
         let mut values = Values::new(b"invalid", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
-        assert_err_eq!(bool::deserialize(deserializer), Error::new(error::Kind::ExpectedBool, Position::new(0, 0)));
+        assert_err_eq!(
+            bool::deserialize(deserializer),
+            Error::new(error::Kind::ExpectedBool, Position::new(0, 0))
+        );
     }
 
     #[test]
@@ -409,7 +450,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"true", Position::new(1, 2));
+        let mut values = Values::new(b"true", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -477,7 +518,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -545,7 +586,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -613,7 +654,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -681,7 +722,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -752,7 +793,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -820,7 +861,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -888,7 +929,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -956,7 +997,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1024,7 +1065,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1095,7 +1136,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1163,7 +1204,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1231,7 +1272,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"42", Position::new(1, 2));
+        let mut values = Values::new(b"42", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1299,7 +1340,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"a", Position::new(1, 2));
+        let mut values = Values::new(b"a", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1367,7 +1408,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"a", Position::new(1, 2));
+        let mut values = Values::new(b"a", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1424,7 +1465,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"a", Position::new(1, 2));
+        let mut values = Values::new(b"a", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1492,7 +1533,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"", Position::new(1, 2));
+        let mut values = Values::new(b"", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1566,7 +1607,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"", Position::new(1, 2));
+        let mut values = Values::new(b"", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(
@@ -1808,7 +1849,7 @@ mod tests {
             }
         }
 
-         let mut values = Values::new(b"a", Position::new(1, 2));
+        let mut values = Values::new(b"a", Position::new(1, 2));
         let deserializer = Deserializer::new(&mut values);
 
         assert_err_eq!(

--- a/src/de/tuple/mod.rs
+++ b/src/de/tuple/mod.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let mut values = Values::new(b"", 0, 0);
+        let mut values = Values::new(b"", Position::new(0, 0));
         // Consume the single unit value, as all values are non-empty.
         assert_ok!(values.next());
         assert_ok!(values.assert_exhausted());
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn one_value() {
-        let mut values = Values::new(b"42", 0, 0);
+        let mut values = Values::new(b"42", Position::new(0, 0));
         let mut access = Access::new(&mut values, 1);
 
         assert_some_eq!(access.size_hint(), 1);
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn multiple_values() {
-        let mut values = Values::new(b"foo:42", 0, 0);
+        let mut values = Values::new(b"foo:42", Position::new(0, 0));
         let mut access = Access::new(&mut values, 2);
 
         assert_some_eq!(access.size_hint(), 2);
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn nested_values() {
-        let mut values = Values::new(b"foo:42::1.2", 0, 0);
+        let mut values = Values::new(b"foo:42::1.2", Position::new(0, 0));
         let mut access = Access::new(&mut values, 3);
 
         assert_some_eq!(access.size_hint(), 3);

--- a/src/de/tuple/mod.rs
+++ b/src/de/tuple/mod.rs
@@ -35,7 +35,7 @@ impl<'a, 'b, 'de> SeqAccess<'de> for Access<'a, 'b> {
 #[cfg(test)]
 mod tests {
     use super::Access;
-    use crate::de::{error, parse::Values, Error};
+    use crate::de::{error, parse::Values, Error, Position};
     use claim::{assert_err_eq, assert_ok, assert_some_eq};
     use serde::de::SeqAccess;
 
@@ -50,7 +50,7 @@ mod tests {
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
             access.next_element::<()>(),
-            Error::new(error::Kind::EndOfValues, 0, 0)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 0))
         );
         assert_some_eq!(access.size_hint(), 0);
     }
@@ -65,7 +65,7 @@ mod tests {
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
             access.next_element::<()>(),
-            Error::new(error::Kind::EndOfValues, 0, 2)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 2))
         );
         assert_some_eq!(access.size_hint(), 0);
     }
@@ -85,7 +85,7 @@ mod tests {
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
             access.next_element::<()>(),
-            Error::new(error::Kind::EndOfValues, 0, 6)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 6))
         );
         assert_some_eq!(access.size_hint(), 0);
     }
@@ -107,7 +107,7 @@ mod tests {
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
             access.next_element::<()>(),
-            Error::new(error::Kind::EndOfValues, 0, 11)
+            Error::new(error::Kind::EndOfValues, Position::new(0, 11))
         );
         assert_some_eq!(access.size_hint(), 0);
     }

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -38,6 +38,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[cfg(test)]
 mod tests {
     use super::Error;
+    use serde::ser::Error as SerdeError;
 
     #[test]
     fn display_unsupported_type_error() {
@@ -55,7 +56,7 @@ mod tests {
     #[test]
     fn display_custom_error() {
         assert_eq!(
-            format!("{}", Error::Custom("custom error message".to_owned())),
+            format!("{}", Error::custom("custom error message")),
             "custom error message"
         );
     }


### PR DESCRIPTION
This fixes #2, making `de::Error` much more flexible and expressive. It adds variants for the different canonical serde deserialization errors, improves custom errors, and includes injection of current position on all user-returned errors during deserialization.