### PR TITLE
Simplify parsing state

### DIFF
--- a/src/de/parse/tag.rs
+++ b/src/de/parse/tag.rs
@@ -319,6 +319,39 @@ mod tests {
     }
 
     #[test]
+    fn end_of_values_after_maybe_entering_comment() {
+        let mut tag = Tag::new(b"foo: /;\n", Position::new(0, 0));
+
+        assert_ok_eq!(tag.next(), Values::new(b"foo: /", Position::new(0, 1)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
+    }
+
+    #[test]
+    fn escaping_after_maybe_entering_comment() {
+        let mut tag = Tag::new(b"foo: /\\;;\n", Position::new(0, 0));
+
+        assert_ok_eq!(tag.next(), Values::new(b"foo: /\\;", Position::new(0, 1)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
+    }
+
+    #[test]
+    fn normal_byte_after_maybe_entering_comment() {
+        let mut tag = Tag::new(b"foo: /bar;\n", Position::new(0, 0));
+
+        assert_ok_eq!(tag.next(), Values::new(b"foo: /bar", Position::new(0, 1)));
+        assert_err_eq!(
+            tag.next(),
+            Error::new(error::Kind::EndOfTag, Position::new(1, 0))
+        );
+    }
+
+    #[test]
     fn escaped_comment() {
         let mut tag = Tag::new(b"foo: \\/\\/comment;\nbar;\n", Position::new(0, 0));
 

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -571,6 +571,43 @@ mod tests {
     }
 
     #[test]
+    fn has_next_character_before_first_tag() {
+        let input = b"foo#bar;\n";
+        let mut tags = Tags::new(input.as_slice());
+
+        assert_err_eq!(
+            tags.has_next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
+    }
+
+    #[test]
+    fn has_next_slash_before_first_tag() {
+        let input = b"/#bar;\n";
+        let mut tags = Tags::new(input.as_slice());
+
+        assert_err_eq!(
+            tags.has_next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
+    }
+
+    #[test]
+    fn has_next_repeats_error() {
+        let input = b"foo#bar;\n";
+        let mut tags = Tags::new(input.as_slice());
+
+        assert_err_eq!(
+            tags.has_next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
+        assert_err_eq!(
+            tags.has_next(),
+            Error::new(error::Kind::ExpectedTag, Position::new(0, 0))
+        );
+    }
+
+    #[test]
     fn revisit() {
         let input = b"#foo;\n";
         let mut tags = Tags::new(input.as_slice());

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -64,7 +64,7 @@ where
                 unsafe { revisit.into_tag() },
             );
         }
-        
+
         let mut state = State::None;
         let mut end_of_values = false;
         let mut starting_new_line = false;
@@ -113,21 +113,19 @@ where
                             }
                         }
                     }
-                    State::MaybeEnteringComment => {
-                        match byte {
-                            b'/' => {
-                                state = State::InComment;
-                            }
-                            _ => {
-                                let error = Error::new(
-                                    error::Kind::ExpectedTag,
-                                    self.current_position.decrement_column(),
-                                );
-                                self.encountered_error = Some(error.clone());
-                                return Err(error);
-                            }
+                    State::MaybeEnteringComment => match byte {
+                        b'/' => {
+                            state = State::InComment;
                         }
-                    }
+                        _ => {
+                            let error = Error::new(
+                                error::Kind::ExpectedTag,
+                                self.current_position.decrement_column(),
+                            );
+                            self.encountered_error = Some(error.clone());
+                            return Err(error);
+                        }
+                    },
                     State::InComment => {
                         // Consume bytes until we are on a new line.
                         if matches!(byte, b'\n') {
@@ -310,21 +308,19 @@ where
                             }
                         }
                     }
-                    State::MaybeEnteringComment => {
-                        match byte {
-                            b'/' => {
-                                state = State::InComment;
-                            }
-                            _ => {
-                                let error = Error::new(
-                                    error::Kind::ExpectedTag,
-                                    self.current_position.decrement_column(),
-                                );
-                                self.encountered_error = Some(error.clone());
-                                return Err(error);
-                            }
+                    State::MaybeEnteringComment => match byte {
+                        b'/' => {
+                            state = State::InComment;
                         }
-                    }
+                        _ => {
+                            let error = Error::new(
+                                error::Kind::ExpectedTag,
+                                self.current_position.decrement_column(),
+                            );
+                            self.encountered_error = Some(error.clone());
+                            return Err(error);
+                        }
+                    },
                     State::InComment => {
                         // Consume bytes until we are on a new line.
                         if matches!(byte, b'\n') {

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -241,6 +241,42 @@ mod tests {
     }
 
     #[test]
+    fn end_of_values_after_maybe_entering_comment() {
+        let mut values = Values::new(b"foo/:bar", Position::new(0, 0));
+
+        assert_ok_eq!(values.next(), Value::new(b"foo/", Position::new(0, 0)));
+        assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(0, 5)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
+    fn escaping_after_maybe_entering_comment() {
+        let mut values = Values::new(b"foo/\\::bar", Position::new(0, 0));
+
+        assert_ok_eq!(values.next(), Value::new(b"foo/\\:", Position::new(0, 0)));
+        assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(0, 7)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 10))
+        );
+    }
+
+    #[test]
+    fn normal_byte_after_maybe_entering_comment() {
+        let mut values = Values::new(b"fo/o:bar", Position::new(0, 0));
+
+        assert_ok_eq!(values.next(), Value::new(b"fo/o", Position::new(0, 0)));
+        assert_ok_eq!(values.next(), Value::new(b"bar", Position::new(0, 5)));
+        assert_err_eq!(
+            values.next(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 8))
+        );
+    }
+
+    #[test]
     fn escaped_comment() {
         let mut values = Values::new(b"foo\\/\\/comment:\n:bar", Position::new(0, 0));
 

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn end_of_values_after_maybe_entering_comment() {
+    fn end_of_value_after_maybe_entering_comment() {
         let mut values = Values::new(b"foo/:bar", Position::new(0, 0));
 
         assert_ok_eq!(values.next(), Value::new(b"foo/", Position::new(0, 0)));


### PR DESCRIPTION
This fixes #6. It greatly simplifies the parsing state, eliminating a bunch of inefficient storage between calls to the `next()` methods. We don't need to store started positions, started indices, comment states, escaping states, etc., between iterations because we always know exactly what those values will be when the iteration starts.