### PR TITLE
Emit errors on unrepresentable types.

### DIFF
--- a/src/de/enum/variant/deserializer.rs
+++ b/src/de/enum/variant/deserializer.rs
@@ -28,35 +28,50 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     #[cfg(has_i128)]
@@ -64,35 +79,50 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     #[cfg(has_i128)]
@@ -100,98 +130,140 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_tuple_struct<V>(
@@ -203,14 +275,20 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_struct<V>(
@@ -222,7 +300,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_enum<V>(
@@ -234,7 +315,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeEnumVariantAsIdentifier,
+            self.value.position(),
+        ))
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
@@ -266,7 +350,9 @@ mod tests {
     use crate::de::{error, parse::Value, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
-    use std::fmt;
+    use serde_bytes::{ByteBuf, Bytes};
+    use serde_derive::Deserialize;
+    use std::{collections::HashMap, fmt};
 
     #[derive(Debug, PartialEq)]
     struct Identifier(String);
@@ -421,6 +507,390 @@ mod tests {
             IgnoredAny::deserialize(deserializer),
             Error::new(
                 error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn bool() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            bool::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i8() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            i8::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i16() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            i16::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i32() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            i32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i64() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            i64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i128() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            i128::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u8() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            u8::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u16() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            u16::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u32() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            u32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u64() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            u64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u128() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            u128::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn f32() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            f32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn f64() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            f64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn char() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            char::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn str() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            <&str>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn string() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            String::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn bytes() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            <&Bytes>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn byte_buf() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            ByteBuf::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn option() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Option::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn unit() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            <()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn unit_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Unit;
+
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Unit::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn newtype_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Newtype(u64);
+
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Newtype::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn seq() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Vec::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn tuple() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            <((),)>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Debug, Deserialize)]
+        struct TupleStruct(String, u64, (), f64);
+
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            TupleStruct::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn map() {
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            HashMap::<(), ()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Debug, Deserialize)]
+        struct Struct {
+            _foo: String,
+            _bar: u64,
+            _baz: (),
+            _qux: f64,
+        }
+
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Struct::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn r#enum() {
+        #[derive(Debug, Deserialize)]
+        enum Enum {}
+
+        let deserializer = Deserializer::new(Value::new(b"foo", Position::new(1, 2)));
+
+        assert_err_eq!(
+            Enum::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeEnumVariantAsIdentifier,
                 Position::new(1, 2)
             )
         );

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -609,10 +609,8 @@ mod tests {
     fn cannot_deserialize_nested_struct() {
         assert_eq!(
             format!(
-                "{}", Error::new(
-                    Kind::CannotDeserializeNestedStruct,
-                    Position::new(39, 40)
-                )
+                "{}",
+                Error::new(Kind::CannotDeserializeNestedStruct, Position::new(39, 40))
             ),
             "cannot deserialize nested struct at line 39 column 40"
         );

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -50,6 +50,10 @@ pub enum Kind {
 
     // Unrepresentable type errors.
     CannotDeserializeAsSelfDescribing,
+    CannotDeserializeAsOptionInTuple,
+    CannotDeserializeAsSeqInTuple,
+    CannotDeserializeAsMapInTuple,
+    CannotDeserializeAsStructInTuple,
 }
 
 impl Display for Kind {
@@ -124,7 +128,21 @@ impl Display for Kind {
             Kind::DuplicateField(field) => {
                 write!(formatter, "duplicate field {}", field)
             }
-            Kind::CannotDeserializeAsSelfDescribing => formatter.write_str("cannot deserialize as self-describing"),
+            Kind::CannotDeserializeAsSelfDescribing => {
+                formatter.write_str("cannot deserialize as self-describing")
+            }
+            Kind::CannotDeserializeAsOptionInTuple => {
+                formatter.write_str("cannot deserialize as option in tuple")
+            }
+            Kind::CannotDeserializeAsSeqInTuple => {
+                formatter.write_str("cannot deserialize as seq in tuple")
+            }
+            Kind::CannotDeserializeAsMapInTuple => {
+                formatter.write_str("cannot deserialize as map in tuple")
+            }
+            Kind::CannotDeserializeAsStructInTuple => {
+                formatter.write_str("cannot deserialize as struct in tuple")
+            }
         }
     }
 }
@@ -522,8 +540,64 @@ mod tests {
     #[test]
     fn cannot_deserialize_as_self_describing() {
         assert_eq!(
-            format!("{}", Error::new(Kind::CannotDeserializeAsSelfDescribing, Position::new(34, 35))),
+            format!(
+                "{}",
+                Error::new(
+                    Kind::CannotDeserializeAsSelfDescribing,
+                    Position::new(34, 35)
+                )
+            ),
             "cannot deserialize as self-describing at line 34 column 35"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_option_in_tuple() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(
+                    Kind::CannotDeserializeAsOptionInTuple,
+                    Position::new(35, 36)
+                )
+            ),
+            "cannot deserialize as option in tuple at line 35 column 36"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_seq_in_tuple() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::CannotDeserializeAsSeqInTuple, Position::new(36, 37))
+            ),
+            "cannot deserialize as seq in tuple at line 36 column 37"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_map_in_tuple() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::CannotDeserializeAsMapInTuple, Position::new(37, 38))
+            ),
+            "cannot deserialize as map in tuple at line 37 column 38"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_struct_in_tuple() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(
+                    Kind::CannotDeserializeAsStructInTuple,
+                    Position::new(38, 39)
+                )
+            ),
+            "cannot deserialize as struct in tuple at line 38 column 39"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -56,6 +56,8 @@ pub enum Kind {
     CannotDeserializeAsStructInTuple,
     CannotDeserializeNestedStruct,
     MustDeserializeStructFieldAsIdentifier,
+    CannotDeserializeAsOptionInSeq,
+    CannotDeserializeNestedSeq,
 }
 
 impl Display for Kind {
@@ -150,6 +152,12 @@ impl Display for Kind {
             }
             Kind::MustDeserializeStructFieldAsIdentifier => {
                 formatter.write_str("must deserialize struct field as identifier")
+            }
+            Kind::CannotDeserializeAsOptionInSeq => {
+                formatter.write_str("cannot deserialize as option in seq")
+            }
+            Kind::CannotDeserializeNestedSeq => {
+                formatter.write_str("cannot deserialize nested seq")
             }
         }
     }
@@ -631,6 +639,34 @@ mod tests {
                 )
             ),
             "must deserialize struct field as identifier at line 40 column 41"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_option_in_seq() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(
+                    Kind::CannotDeserializeAsOptionInSeq,
+                    Position::new(41, 42)
+                )
+            ),
+            "cannot deserialize as option in seq at line 41 column 42"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_nested_seq() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(
+                    Kind::CannotDeserializeNestedSeq,
+                    Position::new(42, 43)
+                )
+            ),
+            "cannot deserialize nested seq at line 42 column 43"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -54,6 +54,7 @@ pub enum Kind {
     CannotDeserializeAsSeqInTuple,
     CannotDeserializeAsMapInTuple,
     CannotDeserializeAsStructInTuple,
+    CannotDeserializeNestedStruct,
 }
 
 impl Display for Kind {
@@ -142,6 +143,9 @@ impl Display for Kind {
             }
             Kind::CannotDeserializeAsStructInTuple => {
                 formatter.write_str("cannot deserialize as struct in tuple")
+            }
+            Kind::CannotDeserializeNestedStruct => {
+                formatter.write_str("cannot deserialize nested struct")
             }
         }
     }
@@ -598,6 +602,19 @@ mod tests {
                 )
             ),
             "cannot deserialize as struct in tuple at line 38 column 39"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_nested_struct() {
+        assert_eq!(
+            format!(
+                "{}", Error::new(
+                    Kind::CannotDeserializeNestedStruct,
+                    Position::new(39, 40)
+                )
+            ),
+            "cannot deserialize nested struct at line 39 column 40"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -55,6 +55,7 @@ pub enum Kind {
     CannotDeserializeAsMapInTuple,
     CannotDeserializeAsStructInTuple,
     CannotDeserializeNestedStruct,
+    MustDeserializeStructFieldAsIdentifier,
 }
 
 impl Display for Kind {
@@ -146,6 +147,9 @@ impl Display for Kind {
             }
             Kind::CannotDeserializeNestedStruct => {
                 formatter.write_str("cannot deserialize nested struct")
+            }
+            Kind::MustDeserializeStructFieldAsIdentifier => {
+                formatter.write_str("must deserialize struct field as identifier")
             }
         }
     }
@@ -613,6 +617,17 @@ mod tests {
                 Error::new(Kind::CannotDeserializeNestedStruct, Position::new(39, 40))
             ),
             "cannot deserialize nested struct at line 39 column 40"
+        );
+    }
+
+    #[test]
+    fn must_deserialize_struct_field_as_identifier() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(Kind::MustDeserializeStructFieldAsIdentifier, Position::new(40, 41))
+            ),
+            "must deserialize struct field as identifier at line 40 column 41"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -625,7 +625,10 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::new(Kind::MustDeserializeStructFieldAsIdentifier, Position::new(40, 41))
+                Error::new(
+                    Kind::MustDeserializeStructFieldAsIdentifier,
+                    Position::new(40, 41)
+                )
             ),
             "must deserialize struct field as identifier at line 40 column 41"
         );

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -58,6 +58,7 @@ pub enum Kind {
     MustDeserializeStructFieldAsIdentifier,
     CannotDeserializeAsOptionInSeq,
     CannotDeserializeNestedSeq,
+    MustDeserializeEnumVariantAsIdentifier,
 }
 
 impl Display for Kind {
@@ -158,6 +159,9 @@ impl Display for Kind {
             }
             Kind::CannotDeserializeNestedSeq => {
                 formatter.write_str("cannot deserialize nested seq")
+            }
+            Kind::MustDeserializeEnumVariantAsIdentifier => {
+                formatter.write_str("must deserialize enum variant as identifier")
             }
         }
     }
@@ -647,10 +651,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::new(
-                    Kind::CannotDeserializeAsOptionInSeq,
-                    Position::new(41, 42)
-                )
+                Error::new(Kind::CannotDeserializeAsOptionInSeq, Position::new(41, 42))
             ),
             "cannot deserialize as option in seq at line 41 column 42"
         );
@@ -661,12 +662,23 @@ mod tests {
         assert_eq!(
             format!(
                 "{}",
-                Error::new(
-                    Kind::CannotDeserializeNestedSeq,
-                    Position::new(42, 43)
-                )
+                Error::new(Kind::CannotDeserializeNestedSeq, Position::new(42, 43))
             ),
             "cannot deserialize nested seq at line 42 column 43"
+        );
+    }
+
+    #[test]
+    fn must_deserialize_enum_variant_as_identifier() {
+        assert_eq!(
+            format!(
+                "{}",
+                Error::new(
+                    Kind::MustDeserializeEnumVariantAsIdentifier,
+                    Position::new(43, 44)
+                )
+            ),
+            "must deserialize enum variant as identifier at line 43 column 44"
         );
     }
 

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -7,6 +7,7 @@ use std::{fmt, fmt::Display};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Kind {
+    // Formatting errors.
     EndOfFile,
     ExpectedTag,
     UnexpectedTag,
@@ -14,6 +15,8 @@ pub enum Kind {
     UnexpectedValues,
     UnexpectedValue,
     EndOfValues,
+
+    // Value errors.
     ExpectedBool,
     ExpectedI8,
     ExpectedI16,
@@ -31,7 +34,11 @@ pub enum Kind {
     ExpectedString,
     ExpectedUnit,
     ExpectedIdentifier,
+
+    // IO-related errors.
     Io,
+
+    // User-provided errors (provided through `serde::de::Error` trait methods).
     Custom(String),
     InvalidType(String, String),
     InvalidValue(String, String),
@@ -40,6 +47,9 @@ pub enum Kind {
     UnknownField(String, &'static [&'static str]),
     MissingField(&'static str),
     DuplicateField(&'static str),
+
+    // Unrepresentable type errors.
+    CannotDeserializeAsSelfDescribing,
 }
 
 impl Display for Kind {
@@ -114,6 +124,7 @@ impl Display for Kind {
             Kind::DuplicateField(field) => {
                 write!(formatter, "duplicate field {}", field)
             }
+            Kind::CannotDeserializeAsSelfDescribing => formatter.write_str("cannot deserialize as self-describing"),
         }
     }
 }
@@ -505,6 +516,14 @@ mod tests {
         assert_eq!(
             format!("{}", error),
             "duplicate field foo at line 33 column 34"
+        );
+    }
+
+    #[test]
+    fn cannot_deserialize_as_self_describing() {
+        assert_eq!(
+            format!("{}", Error::new(Kind::CannotDeserializeAsSelfDescribing, Position::new(34, 35))),
+            "cannot deserialize as self-describing at line 34 column 35"
         );
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -83,7 +83,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(error::Kind::CannotDeserializeAsSelfDescribing, self.tags.current_position()))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -572,7 +572,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(error::Kind::CannotDeserializeAsSelfDescribing, self.tags.current_position()))
     }
 }
 
@@ -2697,5 +2697,57 @@ mod tests {
             CustomIdentifier::deserialize(&mut deserializer),
             Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
         );
+    }
+
+    #[test]
+    fn any() {
+        #[derive(Debug)]
+        struct Any;
+
+        impl<'de> Deserialize<'de> for Any {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: de::Deserializer<'de> {
+                struct AnyVisitor;
+
+                impl<'de> Visitor<'de> for AnyVisitor {
+                    type Value = Any;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_any(AnyVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"".as_slice());
+
+        assert_err_eq!(Any::deserialize(&mut deserializer), Error::new(error::Kind::CannotDeserializeAsSelfDescribing, Position::new(0, 0)));
+    }
+
+    #[test]
+    fn ignored_any() {
+        #[derive(Debug)]
+        struct IgnoredAny;
+
+        impl<'de> Deserialize<'de> for IgnoredAny {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: de::Deserializer<'de> {
+                struct IgnoredAnyVisitor;
+
+                impl<'de> Visitor<'de> for IgnoredAnyVisitor {
+                    type Value = IgnoredAny;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_ignored_any(IgnoredAnyVisitor)
+            }
+        }
+
+        let mut deserializer = Deserializer::new(b"".as_slice());
+
+        assert_err_eq!(IgnoredAny::deserialize(&mut deserializer), Error::new(error::Kind::CannotDeserializeAsSelfDescribing, Position::new(0, 0)));
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -83,10 +83,7 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(Error::new(
-            error::Kind::CannotDeserializeAsSelfDescribing,
-            self.tags.current_position(),
-        ))
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -575,10 +572,7 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(Error::new(
-            error::Kind::CannotDeserializeAsSelfDescribing,
-            self.tags.current_position(),
-        ))
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 }
 
@@ -2729,13 +2723,13 @@ mod tests {
             }
         }
 
-        let mut deserializer = Deserializer::new(b"".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo;".as_slice());
 
         assert_err_eq!(
             Any::deserialize(&mut deserializer),
             Error::new(
                 error::Kind::CannotDeserializeAsSelfDescribing,
-                Position::new(0, 0)
+                Position::new(0, 1)
             )
         );
     }
@@ -2764,13 +2758,13 @@ mod tests {
             }
         }
 
-        let mut deserializer = Deserializer::new(b"".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo;".as_slice());
 
         assert_err_eq!(
             IgnoredAny::deserialize(&mut deserializer),
             Error::new(
                 error::Kind::CannotDeserializeAsSelfDescribing,
-                Position::new(0, 0)
+                Position::new(0, 1)
             )
         );
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -83,7 +83,10 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(Error::new(error::Kind::CannotDeserializeAsSelfDescribing, self.tags.current_position()))
+        Err(Error::new(
+            error::Kind::CannotDeserializeAsSelfDescribing,
+            self.tags.current_position(),
+        ))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -572,7 +575,10 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(Error::new(error::Kind::CannotDeserializeAsSelfDescribing, self.tags.current_position()))
+        Err(Error::new(
+            error::Kind::CannotDeserializeAsSelfDescribing,
+            self.tags.current_position(),
+        ))
     }
 }
 
@@ -2705,7 +2711,10 @@ mod tests {
         struct Any;
 
         impl<'de> Deserialize<'de> for Any {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: de::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
                 struct AnyVisitor;
 
                 impl<'de> Visitor<'de> for AnyVisitor {
@@ -2722,7 +2731,13 @@ mod tests {
 
         let mut deserializer = Deserializer::new(b"".as_slice());
 
-        assert_err_eq!(Any::deserialize(&mut deserializer), Error::new(error::Kind::CannotDeserializeAsSelfDescribing, Position::new(0, 0)));
+        assert_err_eq!(
+            Any::deserialize(&mut deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(0, 0)
+            )
+        );
     }
 
     #[test]
@@ -2731,7 +2746,10 @@ mod tests {
         struct IgnoredAny;
 
         impl<'de> Deserialize<'de> for IgnoredAny {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: de::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
                 struct IgnoredAnyVisitor;
 
                 impl<'de> Visitor<'de> for IgnoredAnyVisitor {
@@ -2748,6 +2766,12 @@ mod tests {
 
         let mut deserializer = Deserializer::new(b"".as_slice());
 
-        assert_err_eq!(IgnoredAny::deserialize(&mut deserializer), Error::new(error::Kind::CannotDeserializeAsSelfDescribing, Position::new(0, 0)));
+        assert_err_eq!(
+            IgnoredAny::deserialize(&mut deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(0, 0)
+            )
+        );
     }
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -83,7 +83,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -572,7 +574,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 }
 

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -303,12 +303,8 @@ where
     pub(in crate::de) fn error_at_current_tag(&mut self, kind: error::Kind) -> Error {
         if let Err(error) = self.to_first_tag() {
             error
-        }
-        else if self.exhausted {
-            Error::new(
-                error::Kind::EndOfFile,
-                self.current_position,
-            )
+        } else if self.exhausted {
+            Error::new(error::Kind::EndOfFile, self.current_position)
         } else {
             Error::new(
                 kind,

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -46,6 +46,10 @@ where
         }
     }
 
+    pub(in crate::de) fn current_position(&self) -> Position {
+        self.current_position
+    }
+
     /// Returns the next tag in the input, if there is one.
     ///
     /// Note that this is not an `Iterator::next()`, because it is impossible for an iterator to
@@ -652,5 +656,23 @@ mod tests {
             tags.assert_exhausted(),
             Error::new(error::Kind::UnexpectedTag, Position::new(0, 0))
         );
+    }
+
+    #[test]
+    fn current_position() {
+        let input = b"#foo;\n";
+        let tags = Tags::new(input.as_slice());
+
+        assert_eq!(tags.current_position(), Position::new(0, 0));
+    }
+
+    #[test]
+    fn current_position_after_iteration() {
+        let input = b"#foo;\n#bar;\n";
+        let mut tags = Tags::new(input.as_slice());
+
+        assert_ok!(tags.next());
+
+        assert_eq!(tags.current_position(), Position::new(1, 0));
     }
 }

--- a/src/de/parse/values.rs
+++ b/src/de/parse/values.rs
@@ -60,6 +60,10 @@ impl<'a> Values<'a> {
         }
     }
 
+    pub(in crate::de) fn current_position(&self) -> Position {
+        self.current_position
+    }
+
     pub(in crate::de) fn next(&mut self) -> Result<Value<'a>> {
         let mut value = None;
         let started_byte_index = self.current_byte_index;
@@ -369,5 +373,12 @@ mod tests {
             unstored_values.next(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 7))
         );
+    }
+
+    #[test]
+    fn current_position() {
+        let values = Values::new(b"foo", Position::new(1, 2));
+
+        assert_eq!(values.current_position(), Position::new(1, 2));
     }
 }

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -339,7 +339,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsOptionInSeq))
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
@@ -387,7 +387,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeNestedSeq))
     }
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value>

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -2399,4 +2399,32 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn option() {
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            Option::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsOptionInSeq,
+                Position::new(0, 1)
+            )
+        );
+    }
+    
+    #[test]
+    fn seq() {
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            Vec::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeNestedSeq,
+                Position::new(0, 1)
+            )
+        );
+    }
 }

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -1,4 +1,4 @@
-use crate::de::{map, parse::Tags, r#enum, r#struct, tuple, Error, Result};
+use crate::de::{error, map, parse::Tags, r#enum, r#struct, tuple, Error, Result};
 use serde::{de, de::Visitor};
 use std::io::Read;
 
@@ -22,7 +22,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -486,7 +486,7 @@ where
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 }
 
@@ -2317,6 +2317,78 @@ mod tests {
         assert_err_eq!(
             CustomIdentifier::deserialize(deserializer),
             Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 1))
+        );
+    }
+
+    #[test]
+    fn any() {
+        #[derive(Debug)]
+        struct Any;
+
+        impl<'de> Deserialize<'de> for Any {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct AnyVisitor;
+
+                impl<'de> Visitor<'de> for AnyVisitor {
+                    type Value = Any;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_any(AnyVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            Any::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(0, 1)
+            )
+        );
+    }
+
+    #[test]
+    fn ignored_any() {
+        #[derive(Debug)]
+        struct IgnoredAny;
+
+        impl<'de> Deserialize<'de> for IgnoredAny {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct IgnoredAnyVisitor;
+
+                impl<'de> Visitor<'de> for IgnoredAnyVisitor {
+                    type Value = IgnoredAny;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_ignored_any(IgnoredAnyVisitor)
+            }
+        }
+
+        let mut tags = Tags::new(b"#foo;".as_slice());
+        let deserializer = Deserializer::new(&mut tags);
+
+        assert_err_eq!(
+            IgnoredAny::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(0, 1)
+            )
         );
     }
 }

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -2413,7 +2413,7 @@ mod tests {
             )
         );
     }
-    
+
     #[test]
     fn seq() {
         let mut tags = Tags::new(b"#foo;".as_slice());
@@ -2421,10 +2421,7 @@ mod tests {
 
         assert_err_eq!(
             Vec::<()>::deserialize(deserializer),
-            Error::new(
-                error::Kind::CannotDeserializeNestedSeq,
-                Position::new(0, 1)
-            )
+            Error::new(error::Kind::CannotDeserializeNestedSeq, Position::new(0, 1))
         );
     }
 }

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -22,7 +22,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -339,7 +341,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsOptionInSeq))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeAsOptionInSeq))
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
@@ -387,7 +391,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeNestedSeq))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeNestedSeq))
     }
 
     fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value>
@@ -486,7 +492,9 @@ where
     where
         V: Visitor<'de>,
     {
-        Err(self.tags.error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
+        Err(self
+            .tags
+            .error_at_current_tag(error::Kind::CannotDeserializeAsSelfDescribing))
     }
 }
 

--- a/src/de/struct/field.rs
+++ b/src/de/struct/field.rs
@@ -1,4 +1,4 @@
-use crate::de::{Error, Position, Result};
+use crate::de::{error, Error, Position, Result};
 use serde::{de, de::Visitor};
 
 pub(in super::super) struct Deserializer<'a> {
@@ -22,42 +22,60 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::CannotDeserializeAsSelfDescribing,
+            self.position,
+        ))
     }
 
     fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     #[cfg(has_i128)]
@@ -65,35 +83,50 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     #[cfg(has_i128)]
@@ -101,98 +134,140 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_newtype_struct<V>(self, _name: &'static str, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_tuple_struct<V>(
@@ -204,14 +279,20 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_struct<V>(
@@ -223,7 +304,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_enum<V>(
@@ -235,7 +319,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+         Err(Error::new(
+            error::Kind::MustDeserializeStructFieldAsIdentifier,
+            self.position,
+        ))
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
@@ -254,7 +341,10 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        Err(Error::new(
+            error::Kind::CannotDeserializeAsSelfDescribing,
+            self.position,
+        ))
     }
 }
 
@@ -264,7 +354,9 @@ mod tests {
     use crate::de::{error, Error, Position};
     use claim::{assert_err_eq, assert_ok_eq};
     use serde::{de, de::Visitor, Deserialize};
-    use std::fmt;
+    use serde_bytes::{ByteBuf, Bytes};
+    use serde_derive::Deserialize;
+    use std::{collections::HashMap, fmt};
 
     #[derive(Debug, PartialEq)]
     struct Identifier(String);
@@ -341,6 +433,460 @@ mod tests {
         assert_err_eq!(
             CustomIdentifier::deserialize(deserializer),
             Error::new(error::Kind::Custom("foo".to_string()), Position::new(1, 2))
+        );
+    }
+
+    #[test]
+    fn any() {
+        #[derive(Debug)]
+        struct Any;
+
+        impl<'de> Deserialize<'de> for Any {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct AnyVisitor;
+
+                impl<'de> Visitor<'de> for AnyVisitor {
+                    type Value = Any;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_any(AnyVisitor)
+            }
+        }
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Any::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn ignored_any() {
+        #[derive(Debug)]
+        struct IgnoredAny;
+
+        impl<'de> Deserialize<'de> for IgnoredAny {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                struct IgnoredAnyVisitor;
+
+                impl<'de> Visitor<'de> for IgnoredAnyVisitor {
+                    type Value = IgnoredAny;
+
+                    fn expecting(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+                        unimplemented!()
+                    }
+                }
+
+                deserializer.deserialize_ignored_any(IgnoredAnyVisitor)
+            }
+        }
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            IgnoredAny::deserialize(deserializer),
+            Error::new(
+                error::Kind::CannotDeserializeAsSelfDescribing,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn bool() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            bool::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i8() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            i8::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i16() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            i16::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i32() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            i32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i64() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            i64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn i128() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            i128::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u8() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            u8::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u16() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            u16::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u32() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            u32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u64() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            u64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn u128() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            u128::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn f32() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            f32::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn f64() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            f64::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn char() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            char::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn str() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            <&str>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn string() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            String::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn bytes() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            <&Bytes>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn byte_buf() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            ByteBuf::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn option() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Option::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn unit() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            <()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn unit_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Unit;
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Unit::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn newtype_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Newtype(u64);
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Newtype::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn seq() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Vec::<()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn tuple() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            <((),)>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn tuple_struct() {
+        #[derive(Debug, Deserialize)]
+        struct TupleStruct(String, u64, (), f64);
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            TupleStruct::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn map() {
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            HashMap::<(), ()>::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Debug, Deserialize)]
+        struct Struct {
+            _foo: String,
+            _bar: u64,
+            _baz: (),
+            _qux: f64,
+        }
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Struct::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
+        );
+    }
+
+    #[test]
+    fn r#enum() {
+        #[derive(Debug, Deserialize)]
+        enum Enum {}
+
+        let deserializer = Deserializer::new("foo", Position::new(1, 2));
+
+        assert_err_eq!(
+            Enum::deserialize(deserializer),
+            Error::new(
+                error::Kind::MustDeserializeStructFieldAsIdentifier,
+                Position::new(1, 2)
+            )
         );
     }
 }

--- a/src/de/struct/field.rs
+++ b/src/de/struct/field.rs
@@ -42,7 +42,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -52,7 +52,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -62,7 +62,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -72,7 +72,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -83,7 +83,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -93,7 +93,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -103,7 +103,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -113,7 +113,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -123,7 +123,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -134,7 +134,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -144,7 +144,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -154,7 +154,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -164,7 +164,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -184,7 +184,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -194,7 +194,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -204,7 +204,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -214,7 +214,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -224,7 +224,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -234,7 +234,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -244,7 +244,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -254,7 +254,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -264,7 +264,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -279,7 +279,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -289,7 +289,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -304,7 +304,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))
@@ -319,7 +319,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-         Err(Error::new(
+        Err(Error::new(
             error::Kind::MustDeserializeStructFieldAsIdentifier,
             self.position,
         ))

--- a/src/de/struct/value.rs
+++ b/src/de/struct/value.rs
@@ -1,6 +1,5 @@
 use crate::de::{
-    error,
-    map,
+    error, map,
     parse::{StoredTag, StoredValues, Tags},
     r#enum, seq, tuple, Error, Result,
 };


### PR DESCRIPTION
Replaces all of the `todo!()` placeholder code with actual error emissions in deserialization. Also adds relevant tests. This finishes part of #4, but some work still needs to be done documentation-wise.