### PR TITLE
Match unserializable types with undeserializable types.

### DIFF
--- a/src/ser/map/key.rs
+++ b/src/ser/map/key.rs
@@ -111,14 +111,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_key_unescaped(b"")
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -208,7 +208,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -574,18 +575,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"   ");
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"   42");
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/map/key.rs
+++ b/src/ser/map/key.rs
@@ -216,6 +216,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -799,5 +800,56 @@ mod tests {
         );
 
         assert_eq!(output, b"   Variant:1:2:3:4:5:6:7");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }

--- a/src/ser/map/tag/key.rs
+++ b/src/ser/map/tag/key.rs
@@ -123,14 +123,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_tag_name_unescaped(b"")
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -220,7 +220,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -586,18 +587,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#");
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#42");
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/map/tag/key.rs
+++ b/src/ser/map/tag/key.rs
@@ -228,6 +228,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -811,5 +812,56 @@ mod tests {
         );
 
         assert_eq!(output, b"#Variant:1:2:3:4:5:6:7");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }

--- a/src/ser/map/value.rs
+++ b/src/ser/map/value.rs
@@ -254,6 +254,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -837,5 +838,56 @@ mod tests {
         );
 
         assert_eq!(output, b":Variant:1:2:3:4:5:6:7;\n");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }

--- a/src/ser/map/value.rs
+++ b/src/ser/map/value.rs
@@ -143,16 +143,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
-        self.writer.close_tag()
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -248,7 +246,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -614,18 +613,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b":;\n");
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b":42;\n");
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/seq/element.rs
+++ b/src/ser/seq/element.rs
@@ -143,16 +143,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
-        self.writer.close_tag()
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -253,7 +251,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeMap, SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -620,18 +619,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b":;\n");
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b":42;\n");
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/seq/element.rs
+++ b/src/ser/seq/element.rs
@@ -967,4 +967,14 @@ mod tests {
 
         assert_eq!(output, b":Variant;\n#foo:42;\n#bar:test;\n#baz:;\n");
     }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
 }

--- a/src/ser/seq/mod.rs
+++ b/src/ser/seq/mod.rs
@@ -77,9 +77,8 @@ mod tests {
         assert_ok!(serializer.serialize_element(&42));
         assert_ok!(serializer.serialize_element(&"bar"));
         assert_ok!(serializer.serialize_element(&()));
-        assert_ok!(serializer.serialize_element::<Option<()>>(&None));
         assert_ok!(serializer.end());
 
-        assert_eq!(output, b"#foo:42;\n#foo:bar;\n#foo:;\n#foo:;\n");
+        assert_eq!(output, b"#foo:42;\n#foo:bar;\n#foo:;\n");
     }
 }

--- a/src/ser/seq/tag/element.rs
+++ b/src/ser/seq/tag/element.rs
@@ -257,6 +257,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -865,5 +866,41 @@ mod tests {
         .serialize(Serializer::new(&mut output)));
 
         assert_eq!(output, b"#Variant:;\n#foo:42;\n#bar:test;\n#baz:;\n");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }

--- a/src/ser/seq/tag/element.rs
+++ b/src/ser/seq/tag/element.rs
@@ -249,8 +249,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::{assert_err_eq, assert_ok};
     use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -616,14 +616,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_err_eq!(Option::<()>::None.serialize(Serializer::new(&mut output)), Error::UnsupportedType);
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_err_eq!(Some(42).serialize(Serializer::new(&mut output)), Error::UnsupportedType);
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/seq/tag/element.rs
+++ b/src/ser/seq/tag/element.rs
@@ -143,16 +143,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_tag_name_unescaped(b"")?;
-
-        self.writer.close_tag()
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -251,7 +249,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use claim::{assert_err_eq, assert_ok};
+    use crate::ser::Error;
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -617,18 +616,14 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#;\n");
+        assert_err_eq!(Option::<()>::None.serialize(Serializer::new(&mut output)), Error::UnsupportedType);
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#42;\n");
+        assert_err_eq!(Some(42).serialize(Serializer::new(&mut output)), Error::UnsupportedType);
     }
 
     #[test]

--- a/src/ser/seq/tag/mod.rs
+++ b/src/ser/seq/tag/mod.rs
@@ -67,9 +67,8 @@ mod tests {
         assert_ok!(serializer.serialize_element(&42));
         assert_ok!(serializer.serialize_element(&"bar"));
         assert_ok!(serializer.serialize_element(&()));
-        assert_ok!(serializer.serialize_element::<Option<()>>(&None));
         assert_ok!(serializer.end());
 
-        assert_eq!(output, b"#42;\n#bar;\n#;\n#;\n");
+        assert_eq!(output, b"#42;\n#bar;\n#;\n");
     }
 }

--- a/src/ser/struct/field.rs
+++ b/src/ser/struct/field.rs
@@ -295,7 +295,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeMap, SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -1141,6 +1142,37 @@ mod tests {
         assert_eq!(
             output,
             b"#foo:\n   abc:1;\n   def:2;\n   ghi:3;\n   jkl:4;\n"
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output, b"foo".to_vec())),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output, b"foo".to_vec())),
+            Error::UnsupportedType
         );
     }
 }

--- a/src/ser/struct/field.rs
+++ b/src/ser/struct/field.rs
@@ -1171,7 +1171,8 @@ mod tests {
         let mut output = Vec::new();
 
         assert_err_eq!(
-            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output, b"foo".to_vec())),
+            Struct::Variant { foo: 0, bar: false }
+                .serialize(Serializer::new(&mut output, b"foo".to_vec())),
             Error::UnsupportedType
         );
     }

--- a/src/ser/tuple/element.rs
+++ b/src/ser/tuple/element.rs
@@ -228,6 +228,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -811,5 +812,56 @@ mod tests {
         );
 
         assert_eq!(output, b":Variant:1:2:3:4:5:6:7");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }

--- a/src/ser/tuple/tag/element.rs
+++ b/src/ser/tuple/tag/element.rs
@@ -123,14 +123,14 @@ where
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        self.writer.write_tag_name_unescaped(b"")
+        Err(Error::UnsupportedType)
     }
 
-    fn serialize_some<T>(self, v: &T) -> Result<Self::Ok>
+    fn serialize_some<T>(self, _v: &T) -> Result<Self::Ok>
     where
         T: ?Sized + Serialize,
     {
-        v.serialize(self)
+        Err(Error::UnsupportedType)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
@@ -220,7 +220,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::assert_ok;
+    use claim::{assert_err_eq, assert_ok};
+    use crate::ser::Error;
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -586,18 +587,14 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_ok!(Option::<()>::None.serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#");
+        assert_err_eq!(Option::<()>::None.serialize(Serializer::new(&mut output)), Error::UnsupportedType);
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_ok!(Some(42).serialize(Serializer::new(&mut output)));
-
-        assert_eq!(output, b"#42");
+        assert_err_eq!(Some(42).serialize(Serializer::new(&mut output)), Error::UnsupportedType);
     }
 
     #[test]

--- a/src/ser/tuple/tag/element.rs
+++ b/src/ser/tuple/tag/element.rs
@@ -220,8 +220,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Serializer;
-    use claim::{assert_err_eq, assert_ok};
     use crate::ser::Error;
+    use claim::{assert_err_eq, assert_ok};
     use serde::{
         ser::{SerializeTupleStruct, SerializeTupleVariant},
         Serialize,
@@ -587,14 +587,20 @@ mod tests {
     fn none() {
         let mut output = Vec::new();
 
-        assert_err_eq!(Option::<()>::None.serialize(Serializer::new(&mut output)), Error::UnsupportedType);
+        assert_err_eq!(
+            Option::<()>::None.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]
     fn some() {
         let mut output = Vec::new();
 
-        assert_err_eq!(Some(42).serialize(Serializer::new(&mut output)), Error::UnsupportedType);
+        assert_err_eq!(
+            Some(42).serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 
     #[test]

--- a/src/ser/tuple/tag/element.rs
+++ b/src/ser/tuple/tag/element.rs
@@ -228,6 +228,7 @@ mod tests {
     };
     use serde_bytes::Bytes;
     use serde_derive::Serialize;
+    use std::collections::HashMap;
 
     #[test]
     fn r#true() {
@@ -811,5 +812,56 @@ mod tests {
         );
 
         assert_eq!(output, b"#Variant:1:2:3:4:5:6:7");
+    }
+
+    #[test]
+    fn seq() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Vec::<()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn map() {
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            HashMap::<(), ()>::new().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn r#struct() {
+        #[derive(Default, Serialize)]
+        struct Struct {
+            foo: u64,
+            bar: bool,
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::default().serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        #[derive(Serialize)]
+        enum Struct {
+            Variant { foo: u64, bar: bool },
+        }
+
+        let mut output = Vec::new();
+
+        assert_err_eq!(
+            Struct::Variant { foo: 0, bar: false }.serialize(Serializer::new(&mut output)),
+            Error::UnsupportedType
+        );
     }
 }


### PR DESCRIPTION
This PR aligns types that can't be serialized with types that can't be deserialized. This helps move towards the goal of this library being able to fully perform round-trip serialization and deserialization actions for any input.