### PR TITLE
Fix Clippy CI action.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: clippy
+        args: -- -D warnings
 
   doc:
     runs-on: ubuntu-latest

--- a/src/de/error.rs
+++ b/src/de/error.rs
@@ -5,7 +5,7 @@ use serde::{
 };
 use std::{fmt, fmt::Display};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Kind {
     // Formatting errors.
     EndOfFile,
@@ -168,7 +168,7 @@ impl Display for Kind {
 }
 
 /// An error that may occur during deserialization.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error {
     position: Position,
     kind: Kind,

--- a/src/de/parse/tags.rs
+++ b/src/de/parse/tags.rs
@@ -46,7 +46,7 @@ where
         }
     }
 
-    pub fn to_first_tag(&mut self) -> Result<()> {
+    fn iterate_to_first_tag(&mut self) -> Result<()> {
         enum State {
             None,
             MaybeEnteringComment,
@@ -152,7 +152,7 @@ where
 
         // Find the first tag, if necessary.
         if self.first_tag {
-            self.to_first_tag()?;
+            self.iterate_to_first_tag()?;
             if self.exhausted {
                 let error = Error::new(error::Kind::EndOfFile, self.current_position);
                 self.encountered_error = Some(error.clone());
@@ -270,7 +270,7 @@ where
     pub(in crate::de) fn has_next(&mut self) -> Result<bool> {
         // The iterator will only be in the state below if no tags have been returned yet.
         // Simply find the first tag if it exists.
-        self.to_first_tag()?;
+        self.iterate_to_first_tag()?;
 
         if let Some(error) = &self.encountered_error {
             Err(error.clone())
@@ -301,7 +301,7 @@ where
     }
 
     pub(in crate::de) fn error_at_current_tag(&mut self, kind: error::Kind) -> Error {
-        if let Err(error) = self.to_first_tag() {
+        if let Err(error) = self.iterate_to_first_tag() {
             error
         } else if self.exhausted {
             Error::new(error::Kind::EndOfFile, self.current_position)

--- a/src/de/parse/value/clean.rs
+++ b/src/de/parse/value/clean.rs
@@ -15,14 +15,14 @@ impl<'a> Iterator for Clean<'a> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let byte = *self.bytes.get(0)?;
+        let byte = *self.bytes.first()?;
         // SAFETY: If `self.bytes` is empty, it will have returned in the previous statement.
         self.bytes = unsafe { self.bytes.get_unchecked(1..) };
 
         match byte {
             b'\\' => {
                 // Possibly escaping the next byte.
-                match self.bytes.get(0).copied() {
+                match self.bytes.first().copied() {
                     Some(next_byte) => match next_byte {
                         b':' | b';' | b'\\' | b'/' | b'#' => {
                             // Escape the character.
@@ -37,11 +37,11 @@ impl<'a> Iterator for Clean<'a> {
             }
             b'/' => {
                 // Possibly entering a comment.
-                match self.bytes.get(0).copied() {
+                match self.bytes.first().copied() {
                     Some(b'/') => {
                         // Inside a comment.
                         loop {
-                            let comment_byte = *self.bytes.get(0)?;
+                            let comment_byte = *self.bytes.first()?;
                             // SAFETY: If `self.bytes` is empty, it will have returned in the
                             // previous statement.
                             self.bytes = unsafe { self.bytes.get_unchecked(1..) };

--- a/src/de/position.rs
+++ b/src/de/position.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::de) struct Position {
     line: usize,
     column: usize,

--- a/src/ser/error.rs
+++ b/src/ser/error.rs
@@ -2,7 +2,7 @@ use serde::ser;
 use std::{fmt, fmt::Display};
 
 /// An error that may occur during serialization.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     UnsupportedType,
     Io,


### PR DESCRIPTION
This fixes #11. Clippy was not properly configured, and as a result it didn't catch any issues introduced by pull requests. This reenables the proper configuration and fixes all clippy warnings.