### PR TITLE
Don't assign unit values an empty parameter.

### DIFF
--- a/src/de/enum/variant/access.rs
+++ b/src/de/enum/variant/access.rs
@@ -94,7 +94,7 @@ mod tests {
             }
         }
 
-        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
+        let mut values = Values::new(b"42:foo:1.2", Position::new(0, 0));
         let access = Access::new(&mut values);
 
         assert_ok_eq!(

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -2386,7 +2386,7 @@ mod tests {
 
     #[test]
     fn tuple_multiple_values() {
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_ok_eq!(
             <(String, u64, (), f64)>::deserialize(&mut deserializer),
@@ -2396,7 +2396,7 @@ mod tests {
 
     #[test]
     fn tuple_nested_values() {
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_ok_eq!(
             <(String, (u64, ()), f64)>::deserialize(&mut deserializer),
@@ -2406,17 +2406,17 @@ mod tests {
 
     #[test]
     fn tuple_too_many_values() {
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_err_eq!(
             <(String, u64, ())>::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
     #[test]
     fn tuple_unexpected_values() {
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\nbar:100;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\nbar:100;\n".as_slice());
 
         assert_err_eq!(
             <(String, u64, (), f64)>::deserialize(&mut deserializer),
@@ -2426,7 +2426,7 @@ mod tests {
 
     #[test]
     fn tuple_unexpected_tag() {
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n#bar:100;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n#bar:100;\n".as_slice());
 
         assert_err_eq!(
             <(String, u64, (), f64)>::deserialize(&mut deserializer),
@@ -2450,7 +2450,7 @@ mod tests {
     fn tuple_struct_multiple_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, u64, (), f64);
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_ok_eq!(
             TupleStruct::deserialize(&mut deserializer),
@@ -2464,7 +2464,7 @@ mod tests {
         struct NestedTupleStruct(u64, ());
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, NestedTupleStruct, f64);
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_ok_eq!(
             TupleStruct::deserialize(&mut deserializer),
@@ -2476,11 +2476,11 @@ mod tests {
     fn tuple_struct_too_many_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, u64, ());
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n".as_slice());
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 9))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 8))
         );
     }
 
@@ -2488,7 +2488,7 @@ mod tests {
     fn tuple_struct_unexpected_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, u64, (), f64);
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\nbar:100;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\nbar:100;\n".as_slice());
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
@@ -2500,7 +2500,7 @@ mod tests {
     fn tuple_struct_unexpected_tag() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, u64, (), f64);
-        let mut deserializer = Deserializer::new(b"#foo:42::1.2;\n#bar:100;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:42:1.2;\n#bar:100;\n".as_slice());
 
         assert_err_eq!(
             TupleStruct::deserialize(&mut deserializer),
@@ -2534,7 +2534,7 @@ mod tests {
             qux: f64,
         }
         let mut deserializer =
-            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz:;\n#qux:1.2;\n".as_slice());
+            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz;\n#qux:1.2;\n".as_slice());
 
         assert_ok_eq!(
             Struct::deserialize(&mut deserializer),
@@ -2557,7 +2557,7 @@ mod tests {
             qux: f64,
         }
         let mut deserializer =
-            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz:;\n#qux:1.2;\n".as_slice());
+            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz;\n#qux:1.2;\n".as_slice());
 
         assert_ok_eq!(
             Struct::deserialize(&mut deserializer),
@@ -2579,7 +2579,7 @@ mod tests {
             baz: (),
             qux: f64,
         }
-        let mut deserializer = Deserializer::new(b"#foo:text;\n#baz:;\n#qux:1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#foo:text;\n#baz;\n#qux:1.2;\n".as_slice());
 
         assert_ok_eq!(
             Struct::deserialize(&mut deserializer),
@@ -2602,7 +2602,7 @@ mod tests {
             qux: HashMap<String, u64>,
         }
         let mut deserializer =
-            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz:;\n#qux:a:1;b:2;c:3;d:4;\n".as_slice());
+            Deserializer::new(b"#foo:text;\n#bar:42;\n#baz;\n#qux:a:1;b:2;c:3;d:4;\n".as_slice());
 
         let mut expected = HashMap::new();
         expected.insert("a".to_owned(), 1);
@@ -2630,7 +2630,7 @@ mod tests {
             qux: f64,
         }
         let mut deserializer =
-            Deserializer::new(b"#bar:42;\n#foo:text;\n#qux:1.2;\n#baz:;\n".as_slice());
+            Deserializer::new(b"#bar:42;\n#foo:text;\n#qux:1.2;\n#baz;\n".as_slice());
 
         assert_ok_eq!(
             Struct::deserialize(&mut deserializer),
@@ -2758,7 +2758,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut deserializer = Deserializer::new(b"#Variant:42:foo::1.2;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#Variant:42:foo:1.2;\n".as_slice());
 
         assert_ok_eq!(
             Tuple::deserialize(&mut deserializer),
@@ -2772,11 +2772,11 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut deserializer = Deserializer::new(b"#Variant:42:foo::1.2:bar;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#Variant:42:foo:1.2:bar;\n".as_slice());
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 21))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 20))
         );
     }
 
@@ -2786,11 +2786,11 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut deserializer = Deserializer::new(b"#Variant:42:foo::1.2;bar;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#Variant:42:foo:1.2;bar;\n".as_slice());
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 21))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 20))
         );
     }
 
@@ -2800,7 +2800,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut deserializer = Deserializer::new(b"#Variant:42:foo::1.2;\n#bar;\n".as_slice());
+        let mut deserializer = Deserializer::new(b"#Variant:42:foo:1.2;\n#bar;\n".as_slice());
 
         assert_err_eq!(
             Tuple::deserialize(&mut deserializer),

--- a/src/de/seq/element.rs
+++ b/src/de/seq/element.rs
@@ -2178,7 +2178,7 @@ mod tests {
 
     #[test]
     fn tuple() {
-        let mut tags = Tags::new(b"#42:foo::1.2;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_ok_eq!(
@@ -2189,23 +2189,23 @@ mod tests {
 
     #[test]
     fn tuple_too_many_values() {
-        let mut tags = Tags::new(b"#42:foo::1.2:bar;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2:bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 13))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 12))
         );
     }
 
     #[test]
     fn tuple_unexpected_values() {
-        let mut tags = Tags::new(b"#42:foo::1.2;bar;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2;bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 13))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 12))
         );
     }
 
@@ -2213,7 +2213,7 @@ mod tests {
     fn tuple_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#42:foo::1.2;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_ok_eq!(
@@ -2226,12 +2226,12 @@ mod tests {
     fn tuple_struct_too_many_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#42:foo::1.2:bar;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2:bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 13))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 12))
         );
     }
 
@@ -2239,12 +2239,12 @@ mod tests {
     fn tuple_struct_unexpected_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#42:foo::1.2;bar;".as_slice());
+        let mut tags = Tags::new(b"#42:foo:1.2;bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 13))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 12))
         );
     }
 
@@ -2270,7 +2270,7 @@ mod tests {
             baz: (),
             qux: f64,
         }
-        let mut tags = Tags::new(b"#;\n#foo:test;\n#bar:42;\n#baz:;\n#qux:1.2;\n".as_slice());
+        let mut tags = Tags::new(b"#;\n#foo:test;\n#bar:42;\n#baz;\n#qux:1.2;\n".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_ok_eq!(
@@ -2374,7 +2374,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#Variant:42:foo::1.2;".as_slice());
+        let mut tags = Tags::new(b"#Variant:42:foo:1.2;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_ok_eq!(
@@ -2389,12 +2389,12 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#Variant:42:foo::1.2:bar;".as_slice());
+        let mut tags = Tags::new(b"#Variant:42:foo:1.2:bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 21))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 20))
         );
     }
 
@@ -2404,12 +2404,12 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#Variant:42:foo::1.2;bar;".as_slice());
+        let mut tags = Tags::new(b"#Variant:42:foo:1.2;bar;".as_slice());
         let deserializer = Deserializer::new(&mut tags);
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 21))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 20))
         );
     }
 

--- a/src/de/struct/value.rs
+++ b/src/de/struct/value.rs
@@ -349,14 +349,11 @@ where
     where
         V: Visitor<'de>,
     {
-        let mut values = unsafe { self.values.into_values() };
-        let value = values.next()?;
-        let value_position = value.position();
-        value.parse_unit()?;
+        let values = unsafe { self.values.into_values() };
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
         visitor.visit_unit().map_err(|mut error: Error| {
-            error.set_position(value_position);
+            error.set_position(values.current_position());
             error
         })
     }
@@ -365,14 +362,11 @@ where
     where
         V: Visitor<'de>,
     {
-        let mut values = unsafe { self.values.into_values() };
-        let value = values.next()?;
-        let value_position = value.position();
-        value.parse_unit()?;
+        let values = unsafe { self.values.into_values() };
         values.assert_exhausted()?;
         unsafe { self.tag.into_tag() }.assert_exhausted()?;
         visitor.visit_unit().map_err(|mut error: Error| {
-            error.set_position(value_position);
+            error.set_position(values.current_position());
             error
         })
     }
@@ -2474,7 +2468,7 @@ mod tests {
 
     #[test]
     fn unit() {
-        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2486,24 +2480,8 @@ mod tests {
     }
 
     #[test]
-    fn unit_invalid() {
-        let mut tags = Tags::new(b"#foo:invalid;\n".as_slice());
-        let mut tag = assert_ok!(tags.next());
-        let mut values = assert_ok!(tag.next());
-        let _field = assert_ok!(values.next());
-        let stored_tag = tag.into_stored();
-        let stored_values = values.into_stored();
-        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
-
-        assert_err_eq!(
-            <()>::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, Position::new(0, 5))
-        );
-    }
-
-    #[test]
     fn unit_too_many_values() {
-        let mut tags = Tags::new(b"#foo::;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2513,13 +2491,13 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
     #[test]
     fn unit_unexpected_values() {
-        let mut tags = Tags::new(b"#foo:;;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2529,7 +2507,7 @@ mod tests {
 
         assert_err_eq!(
             <()>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -2564,7 +2542,7 @@ mod tests {
             }
         }
 
-        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2574,7 +2552,7 @@ mod tests {
 
         assert_err_eq!(
             CustomUnit::deserialize(deserializer),
-            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 4))
         );
     }
 
@@ -2582,7 +2560,7 @@ mod tests {
     fn unit_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
-        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2594,28 +2572,10 @@ mod tests {
     }
 
     #[test]
-    fn unit_struct_invalid() {
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Unit;
-        let mut tags = Tags::new(b"#foo:invalid;\n".as_slice());
-        let mut tag = assert_ok!(tags.next());
-        let mut values = assert_ok!(tag.next());
-        let _field = assert_ok!(values.next());
-        let stored_tag = tag.into_stored();
-        let stored_values = values.into_stored();
-        let deserializer = Deserializer::new("foo", &mut tags, stored_tag, stored_values);
-
-        assert_err_eq!(
-            Unit::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, Position::new(0, 5))
-        );
-    }
-
-    #[test]
     fn unit_struct_too_many_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
-        let mut tags = Tags::new(b"#foo::;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2625,7 +2585,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 6))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 5))
         );
     }
 
@@ -2633,7 +2593,7 @@ mod tests {
     fn unit_struct_unexpected_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct Unit;
-        let mut tags = Tags::new(b"#foo:;;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2643,7 +2603,7 @@ mod tests {
 
         assert_err_eq!(
             Unit::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 6))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 5))
         );
     }
 
@@ -2678,7 +2638,7 @@ mod tests {
             }
         }
 
-        let mut tags = Tags::new(b"#foo:;\n".as_slice());
+        let mut tags = Tags::new(b"#foo;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2688,7 +2648,7 @@ mod tests {
 
         assert_err_eq!(
             CustomUnitStruct::deserialize(deserializer),
-            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 5))
+            Error::new(error::Kind::Custom("foo".to_string()), Position::new(0, 4))
         );
     }
 
@@ -2707,7 +2667,7 @@ mod tests {
 
     #[test]
     fn tuple() {
-        let mut tags = Tags::new(b"#foo:42:foo::1.2;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2723,7 +2683,7 @@ mod tests {
 
     #[test]
     fn tuple_too_many_values() {
-        let mut tags = Tags::new(b"#foo:42:foo::1.2:100:bar::2.4;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2:100:bar:2.4;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2733,13 +2693,13 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 17))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 16))
         );
     }
 
     #[test]
     fn tuple_unexpected_values() {
-        let mut tags = Tags::new(b"#foo:42:foo::1.2;100:bar::2.4;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2;100:bar:2.4;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2749,7 +2709,7 @@ mod tests {
 
         assert_err_eq!(
             <(u64, String, (), f64)>::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 17))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 16))
         );
     }
 
@@ -2757,7 +2717,7 @@ mod tests {
     fn tuple_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#foo:42:foo::1.2;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2775,7 +2735,7 @@ mod tests {
     fn tuple_struct_too_many_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#foo:42:foo::1.2:100:bar::2.4;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2:100:bar:2.4;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2785,7 +2745,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 17))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 16))
         );
     }
 
@@ -2793,7 +2753,7 @@ mod tests {
     fn tuple_struct_unexpected_values() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut tags = Tags::new(b"#foo:42:foo::1.2;100:bar::2.4;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:42:foo:1.2;100:bar:2.4;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2803,7 +2763,7 @@ mod tests {
 
         assert_err_eq!(
             TupleStruct::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 17))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 16))
         );
     }
 
@@ -2945,7 +2905,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#foo:Variant:42:foo::1.2;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:Variant:42:foo:1.2;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2965,7 +2925,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#foo:Variant:42:foo::1.2:bar;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:Variant:42:foo:1.2:bar;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2975,7 +2935,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValue, Position::new(0, 25))
+            Error::new(error::Kind::UnexpectedValue, Position::new(0, 24))
         );
     }
 
@@ -2985,7 +2945,7 @@ mod tests {
         enum Tuple {
             Variant(u64, String, (), f64),
         }
-        let mut tags = Tags::new(b"#foo:Variant:42:foo::1.2;bar;\n".as_slice());
+        let mut tags = Tags::new(b"#foo:Variant:42:foo:1.2;bar;\n".as_slice());
         let mut tag = assert_ok!(tags.next());
         let mut values = assert_ok!(tag.next());
         let _field = assert_ok!(values.next());
@@ -2995,7 +2955,7 @@ mod tests {
 
         assert_err_eq!(
             Tuple::deserialize(deserializer),
-            Error::new(error::Kind::UnexpectedValues, Position::new(0, 25))
+            Error::new(error::Kind::UnexpectedValues, Position::new(0, 24))
         );
     }
 

--- a/src/de/tuple/element.rs
+++ b/src/de/tuple/element.rs
@@ -274,10 +274,8 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        let value = self.values.next()?;
-        value.parse_unit()?;
         visitor.visit_unit().map_err(|mut error: Error| {
-            error.set_position(value.position());
+            error.set_position(self.values.current_position());
             error
         })
     }
@@ -286,10 +284,8 @@ impl<'a, 'b, 'de> serde::Deserializer<'de> for Deserializer<'a, 'b> {
     where
         V: Visitor<'de>,
     {
-        let value = self.values.next()?;
-        value.parse_unit()?;
         visitor.visit_unit().map_err(|mut error: Error| {
-            error.set_position(value.position());
+            error.set_position(self.values.current_position());
             error
         })
     }
@@ -1684,17 +1680,6 @@ mod tests {
     }
 
     #[test]
-    fn unit_invalid() {
-        let mut values = Values::new(b"invalid", Position::new(0, 0));
-        let deserializer = Deserializer::new(&mut values);
-
-        assert_err_eq!(
-            <()>::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, Position::new(0, 0))
-        );
-    }
-
-    #[test]
     fn unit_multiple_values() {
         // The entire values iterator is not consumed. Just the first value is returned.
         let mut values = Values::new(b":", Position::new(0, 0));
@@ -1751,19 +1736,6 @@ mod tests {
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(Unit::deserialize(deserializer), Unit);
-    }
-
-    #[test]
-    fn unit_struct_invalid() {
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Unit;
-        let mut values = Values::new(b"invalid", Position::new(0, 0));
-        let deserializer = Deserializer::new(&mut values);
-
-        assert_err_eq!(
-            Unit::deserialize(deserializer),
-            Error::new(error::Kind::ExpectedUnit, Position::new(0, 0))
-        );
     }
 
     #[test]
@@ -1840,7 +1812,7 @@ mod tests {
 
     #[test]
     fn tuple() {
-        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
+        let mut values = Values::new(b"42:foo:1.2", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -1853,7 +1825,7 @@ mod tests {
     fn tuple_trailing_values() {
         // The entire values iterator is not consumed. Just the requested tuple values are
         // consumed.
-        let mut values = Values::new(b"42:foo::1.2:not:consumed", Position::new(0, 0));
+        let mut values = Values::new(b"42:foo:1.2:not:consumed", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -1866,7 +1838,7 @@ mod tests {
     fn tuple_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(u64, String, (), f64);
-        let mut values = Values::new(b"42:foo::1.2", Position::new(0, 0));
+        let mut values = Values::new(b"42:foo:1.2", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(
@@ -1881,7 +1853,7 @@ mod tests {
         struct TupleStruct(u64, String, (), f64);
         // The entire values iterator is not consumed. Just the requested tuple values are
         // consumed.
-        let mut values = Values::new(b"42:foo::1.2:not:consumed", Position::new(0, 0));
+        let mut values = Values::new(b"42:foo:1.2:not:consumed", Position::new(0, 0));
         let deserializer = Deserializer::new(&mut values);
 
         assert_ok_eq!(

--- a/src/de/tuple/mod.rs
+++ b/src/de/tuple/mod.rs
@@ -42,14 +42,14 @@ mod tests {
     #[test]
     fn empty() {
         let mut values = Values::new(b"", Position::new(0, 0));
-        // Consume the single unit value, as all values are non-empty.
+        // Consume the single value, as all values are non-empty.
         assert_ok!(values.next());
         assert_ok!(values.assert_exhausted());
         let mut access = Access::new(&mut values, 0);
 
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
-            access.next_element::<()>(),
+            access.next_element::<bool>(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 0))
         );
         assert_some_eq!(access.size_hint(), 0);
@@ -64,7 +64,7 @@ mod tests {
         assert_some_eq!(assert_ok!(access.next_element::<u64>()), 42);
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
-            access.next_element::<()>(),
+            access.next_element::<bool>(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 2))
         );
         assert_some_eq!(access.size_hint(), 0);
@@ -84,7 +84,7 @@ mod tests {
         assert_some_eq!(assert_ok!(access.next_element::<u64>()), 42);
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
-            access.next_element::<()>(),
+            access.next_element::<bool>(),
             Error::new(error::Kind::EndOfValues, Position::new(0, 6))
         );
         assert_some_eq!(access.size_hint(), 0);
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn nested_values() {
-        let mut values = Values::new(b"foo:42::1.2", Position::new(0, 0));
+        let mut values = Values::new(b"foo:42:1.2", Position::new(0, 0));
         let mut access = Access::new(&mut values, 3);
 
         assert_some_eq!(access.size_hint(), 3);
@@ -106,8 +106,8 @@ mod tests {
         assert_some_eq!(assert_ok!(access.next_element::<f64>()), 1.2);
         assert_some_eq!(access.size_hint(), 0);
         assert_err_eq!(
-            access.next_element::<()>(),
-            Error::new(error::Kind::EndOfValues, Position::new(0, 11))
+            access.next_element::<bool>(),
+            Error::new(error::Kind::EndOfValues, Position::new(0, 10))
         );
         assert_some_eq!(access.size_hint(), 0);
     }

--- a/src/ser/map/key.rs
+++ b/src/ser/map/key.rs
@@ -677,7 +677,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"   42:bar::1.0");
+        assert_eq!(output, b"   42:bar:1.0");
     }
 
     #[test]
@@ -722,7 +722,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"   42:bar::1.0");
+        assert_eq!(output, b"   42:bar:1.0");
     }
 
     #[test]
@@ -783,7 +783,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"   Variant:42:bar::1.0");
+        assert_eq!(output, b"   Variant:42:bar:1.0");
     }
 
     #[test]

--- a/src/ser/map/tag/key.rs
+++ b/src/ser/map/tag/key.rs
@@ -689,7 +689,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0");
+        assert_eq!(output, b"#42:bar:1.0");
     }
 
     #[test]
@@ -734,7 +734,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0");
+        assert_eq!(output, b"#42:bar:1.0");
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:42:bar::1.0");
+        assert_eq!(output, b"#Variant:42:bar:1.0");
     }
 
     #[test]

--- a/src/ser/map/value.rs
+++ b/src/ser/map/value.rs
@@ -154,14 +154,10 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
         self.writer.close_tag()
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
         self.writer.close_tag()
     }
 
@@ -636,7 +632,7 @@ mod tests {
 
         assert_ok!(().serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":;\n");
+        assert_eq!(output, b";\n");
     }
 
     #[test]
@@ -648,7 +644,7 @@ mod tests {
 
         assert_ok!(Bar.serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":;\n");
+        assert_eq!(output, b";\n");
     }
 
     #[test]
@@ -715,7 +711,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0;\n");
+        assert_eq!(output, b":42:bar:1.0;\n");
     }
 
     #[test]
@@ -760,7 +756,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0;\n");
+        assert_eq!(output, b":42:bar:1.0;\n");
     }
 
     #[test]
@@ -821,7 +817,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":Variant:42:bar::1.0;\n");
+        assert_eq!(output, b":Variant:42:bar:1.0;\n");
     }
 
     #[test]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -838,7 +838,7 @@ mod tests {
         ]
         .serialize(&mut Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:;\n#foo:1;\n#bar:abc;\n#baz:;\n#Variant:;\n#foo:2;\n#bar:def;\n#baz:;\n#qux:1.1;\n#Variant:;\n#foo:3;\n#bar:ghi;\n#baz:;\n");
+        assert_eq!(output, b"#Variant:;\n#foo:1;\n#bar:abc;\n#baz;\n#Variant:;\n#foo:2;\n#bar:def;\n#baz;\n#qux:1.1;\n#Variant:;\n#foo:3;\n#bar:ghi;\n#baz;\n");
     }
 
     #[test]
@@ -865,7 +865,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(&mut Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0;\n");
+        assert_eq!(output, b"#42:bar:1.0;\n");
     }
 
     #[test]
@@ -919,7 +919,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(&mut Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0;\n");
+        assert_eq!(output, b"#42:bar:1.0;\n");
     }
 
     #[test]
@@ -985,7 +985,7 @@ mod tests {
 
         assert_ok!(Tuple::Variant(42, "bar", (), 1.0).serialize(&mut Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:42:bar::1.0;\n");
+        assert_eq!(output, b"#Variant:42:bar:1.0;\n");
     }
 
     #[test]

--- a/src/ser/seq/element.rs
+++ b/src/ser/seq/element.rs
@@ -154,14 +154,10 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
         self.writer.close_tag()
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")?;
-
         self.writer.close_tag()
     }
 
@@ -641,7 +637,7 @@ mod tests {
 
         assert_ok!(().serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":;\n");
+        assert_eq!(output, b";\n");
     }
 
     #[test]
@@ -653,7 +649,7 @@ mod tests {
 
         assert_ok!(Bar.serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":;\n");
+        assert_eq!(output, b";\n");
     }
 
     #[test]
@@ -721,7 +717,7 @@ mod tests {
         })
         .serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":Variant:;\n#foo:42;\n#bar:test;\n#baz:;\n");
+        assert_eq!(output, b":Variant:;\n#foo:42;\n#bar:test;\n#baz;\n");
     }
 
     #[test]
@@ -748,7 +744,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0;\n");
+        assert_eq!(output, b":42:bar:1.0;\n");
     }
 
     #[test]
@@ -793,7 +789,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0;\n");
+        assert_eq!(output, b":42:bar:1.0;\n");
     }
 
     #[test]
@@ -854,7 +850,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":Variant:42:bar::1.0;\n");
+        assert_eq!(output, b":Variant:42:bar:1.0;\n");
     }
 
     #[test]
@@ -940,7 +936,7 @@ mod tests {
         }
         .serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":;\n#foo:42;\n#bar:test;\n#baz:;\n");
+        assert_eq!(output, b":;\n#foo:42;\n#bar:test;\n#baz;\n");
     }
 
     #[test]
@@ -965,7 +961,7 @@ mod tests {
         }
         .serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":Variant;\n#foo:42;\n#bar:test;\n#baz:;\n");
+        assert_eq!(output, b":Variant;\n#foo:42;\n#bar:test;\n#baz;\n");
     }
 
     #[test]

--- a/src/ser/seq/mod.rs
+++ b/src/ser/seq/mod.rs
@@ -79,6 +79,6 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.end());
 
-        assert_eq!(output, b"#foo:42;\n#foo:bar;\n#foo:;\n");
+        assert_eq!(output, b"#foo:42;\n#foo:bar;\n#foo;\n");
     }
 }

--- a/src/ser/seq/tag/element.rs
+++ b/src/ser/seq/tag/element.rs
@@ -718,7 +718,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0;\n");
+        assert_eq!(output, b"#42:bar:1.0;\n");
     }
 
     #[test]
@@ -763,7 +763,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0;\n");
+        assert_eq!(output, b"#42:bar:1.0;\n");
     }
 
     #[test]
@@ -824,7 +824,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:42:bar::1.0;\n");
+        assert_eq!(output, b"#Variant:42:bar:1.0;\n");
     }
 
     #[test]
@@ -865,7 +865,7 @@ mod tests {
         }
         .serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:;\n#foo:42;\n#bar:test;\n#baz:;\n");
+        assert_eq!(output, b"#Variant:;\n#foo:42;\n#bar:test;\n#baz;\n");
     }
 
     #[test]

--- a/src/ser/struct/field.rs
+++ b/src/ser/struct/field.rs
@@ -192,14 +192,12 @@ where
     fn serialize_unit(self) -> Result<Self::Ok> {
         self.writer
             .write_tag_name_unescaped(&self.escaped_field_name)?;
-        self.writer.write_parameter_unescaped(b"")?;
         self.writer.close_tag()
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
         self.writer
             .write_tag_name_unescaped(&self.escaped_field_name)?;
-        self.writer.write_parameter_unescaped(b"")?;
         self.writer.close_tag()
     }
 
@@ -683,7 +681,7 @@ mod tests {
 
         assert_ok!(().serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:;\n");
+        assert_eq!(output, b"#foo;\n");
     }
 
     #[test]
@@ -695,7 +693,7 @@ mod tests {
 
         assert_ok!(Bar.serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:;\n");
+        assert_eq!(output, b"#foo;\n");
     }
 
     #[test]
@@ -771,7 +769,7 @@ mod tests {
 
         assert_ok!(vec![(), (), ()].serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:;\n#foo:;\n#foo:;\n");
+        assert_eq!(output, b"#foo;\n#foo;\n#foo;\n");
     }
 
     #[test]
@@ -876,7 +874,7 @@ mod tests {
         ]
         .serialize(Serializer::new(&mut output, b"repeating".to_vec())));
 
-        assert_eq!(output, b"#repeating:;\n#foo:1;\n#bar:abc;\n#baz:;\n#repeating:;\n#foo:2;\n#bar:def;\n#baz:;\n#qux:1.1;\n#repeating:;\n#foo:3;\n#bar:ghi;\n#baz:;\n");
+        assert_eq!(output, b"#repeating:;\n#foo:1;\n#bar:abc;\n#baz;\n#repeating:;\n#foo:2;\n#bar:def;\n#baz;\n#qux:1.1;\n#repeating:;\n#foo:3;\n#bar:ghi;\n#baz;\n");
     }
 
     #[test]
@@ -915,7 +913,7 @@ mod tests {
         ]
         .serialize(Serializer::new(&mut output, b"repeating".to_vec())));
 
-        assert_eq!(output, b"#repeating:Variant;\n#foo:1;\n#bar:abc;\n#baz:;\n#repeating:Variant;\n#foo:2;\n#bar:def;\n#baz:;\n#qux:1.1;\n#repeating:Variant;\n#foo:3;\n#bar:ghi;\n#baz:;\n");
+        assert_eq!(output, b"#repeating:Variant;\n#foo:1;\n#bar:abc;\n#baz;\n#repeating:Variant;\n#foo:2;\n#bar:def;\n#baz;\n#qux:1.1;\n#repeating:Variant;\n#foo:3;\n#bar:ghi;\n#baz;\n");
     }
 
     #[test]
@@ -945,7 +943,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:42:bar::1.0;\n");
+        assert_eq!(output, b"#foo:42:bar:1.0;\n");
     }
 
     #[test]
@@ -1002,7 +1000,7 @@ mod tests {
         assert_ok!(TupleStruct(42, "bar", (), 1.0)
             .serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:42:bar::1.0;\n");
+        assert_eq!(output, b"#foo:42:bar:1.0;\n");
     }
 
     #[test]
@@ -1077,7 +1075,7 @@ mod tests {
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0)
             .serialize(Serializer::new(&mut output, b"foo".to_vec())));
 
-        assert_eq!(output, b"#foo:Variant:42:bar::1.0;\n");
+        assert_eq!(output, b"#foo:Variant:42:bar:1.0;\n");
     }
 
     #[test]

--- a/src/ser/tuple/element.rs
+++ b/src/ser/tuple/element.rs
@@ -134,11 +134,11 @@ where
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")
+        Ok(())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
-        self.writer.write_parameter_unescaped(b"")
+        Ok(())
     }
 
     fn serialize_unit_variant(
@@ -610,7 +610,7 @@ mod tests {
 
         assert_ok!(().serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":");
+        assert_eq!(output, b"");
     }
 
     #[test]
@@ -622,7 +622,7 @@ mod tests {
 
         assert_ok!(Bar.serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":");
+        assert_eq!(output, b"");
     }
 
     #[test]
@@ -689,7 +689,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0");
+        assert_eq!(output, b":42:bar:1.0");
     }
 
     #[test]
@@ -734,7 +734,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":42:bar::1.0");
+        assert_eq!(output, b":42:bar:1.0");
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b":Variant:42:bar::1.0");
+        assert_eq!(output, b":Variant:42:bar:1.0");
     }
 
     #[test]

--- a/src/ser/tuple/key.rs
+++ b/src/ser/tuple/key.rs
@@ -147,7 +147,7 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.serialize_element(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"   42:foo::1.0");
+        assert_eq!(output, b"   42:foo:1.0");
     }
 
     #[test]
@@ -188,7 +188,7 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"   42:foo::1.0");
+        assert_eq!(output, b"   42:foo:1.0");
     }
 
     #[test]
@@ -229,6 +229,6 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"   42:foo::1.0");
+        assert_eq!(output, b"   42:foo:1.0");
     }
 }

--- a/src/ser/tuple/mod.rs
+++ b/src/ser/tuple/mod.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.serialize_element(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0;\n");
+        assert_eq!(output, b":42:foo:1.0;\n");
     }
 
     #[test]
@@ -161,7 +161,7 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0;\n");
+        assert_eq!(output, b":42:foo:1.0;\n");
     }
 
     #[test]
@@ -202,6 +202,6 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0;\n");
+        assert_eq!(output, b":42:foo:1.0;\n");
     }
 }

--- a/src/ser/tuple/nested.rs
+++ b/src/ser/tuple/nested.rs
@@ -116,7 +116,7 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.serialize_element(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0");
+        assert_eq!(output, b":42:foo:1.0");
     }
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0");
+        assert_eq!(output, b":42:foo:1.0");
     }
 
     #[test]
@@ -198,6 +198,6 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b":42:foo::1.0");
+        assert_eq!(output, b":42:foo:1.0");
     }
 }

--- a/src/ser/tuple/tag/element.rs
+++ b/src/ser/tuple/tag/element.rs
@@ -689,7 +689,7 @@ mod tests {
 
         assert_ok!((42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0");
+        assert_eq!(output, b"#42:bar:1.0");
     }
 
     #[test]
@@ -734,7 +734,7 @@ mod tests {
 
         assert_ok!(TupleStruct(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#42:bar::1.0");
+        assert_eq!(output, b"#42:bar:1.0");
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
 
         assert_ok!(TupleEnum::Variant(42, "bar", (), 1.0).serialize(Serializer::new(&mut output)));
 
-        assert_eq!(output, b"#Variant:42:bar::1.0");
+        assert_eq!(output, b"#Variant:42:bar:1.0");
     }
 
     #[test]

--- a/src/ser/tuple/tag/mod.rs
+++ b/src/ser/tuple/tag/mod.rs
@@ -149,7 +149,7 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.serialize_element(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0;\n");
+        assert_eq!(output, b"#42:foo:1.0;\n");
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0;\n");
+        assert_eq!(output, b"#42:foo:1.0;\n");
     }
 
     #[test]
@@ -231,6 +231,6 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0;\n");
+        assert_eq!(output, b"#42:foo:1.0;\n");
     }
 }

--- a/src/ser/tuple/tag/nested.rs
+++ b/src/ser/tuple/tag/nested.rs
@@ -146,7 +146,7 @@ mod tests {
         assert_ok!(serializer.serialize_element(&()));
         assert_ok!(serializer.serialize_element(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0");
+        assert_eq!(output, b"#42:foo:1.0");
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0");
+        assert_eq!(output, b"#42:foo:1.0");
     }
 
     #[test]
@@ -228,6 +228,6 @@ mod tests {
         assert_ok!(serializer.serialize_field(&()));
         assert_ok!(serializer.serialize_field(&1.0));
         assert_ok!(serializer.end());
-        assert_eq!(output, b"#42:foo::1.0");
+        assert_eq!(output, b"#42:foo:1.0");
     }
 }


### PR DESCRIPTION
Fixes #21. This treats units and unit structs as non-existent data. If a user wants an empty parameter instead, they'll need to serialize as an empty string instead.