### PR TITLE
Don't skip fields when deserializing structs at root.

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -522,13 +522,13 @@ where
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        let result = visitor.visit_map(r#struct::Access::new(&mut self.tags, fields))?;
+        let result = visitor.visit_map(r#struct::root::Access::new(&mut self.tags))?;
         self.tags.assert_exhausted()?;
         Ok(result)
     }

--- a/src/de/seq/field.rs
+++ b/src/de/seq/field.rs
@@ -4,12 +4,12 @@ use serde::de::{DeserializeSeed, SeqAccess};
 use std::io::Read;
 
 pub(in crate::de) struct Access<'a, R> {
-    field: &'static str,
+    field: &'a str,
     tags: &'a mut Tags<R>,
 }
 
 impl<'a, R> Access<'a, R> {
-    pub(in crate::de) fn new(field: &'static str, tags: &'a mut Tags<R>) -> Self {
+    pub(in crate::de) fn new(field: &'a str, tags: &'a mut Tags<R>) -> Self {
         Self { field, tags }
     }
 }

--- a/src/de/struct/value.rs
+++ b/src/de/struct/value.rs
@@ -7,7 +7,7 @@ use serde::{de, de::Visitor};
 use std::io::Read;
 
 pub(in super::super) struct Deserializer<'a, R> {
-    field: &'static str,
+    field: &'a str,
     tags: &'a mut Tags<R>,
 
     tag: StoredTag,
@@ -16,7 +16,7 @@ pub(in super::super) struct Deserializer<'a, R> {
 
 impl<'a, R> Deserializer<'a, R> {
     pub(in super::super) fn new(
-        field: &'static str,
+        field: &'a str,
         tags: &'a mut Tags<R>,
         tag: StoredTag,
         values: StoredValues,


### PR DESCRIPTION
Fixes #18. 